### PR TITLE
Add partial Windows CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,17 +16,19 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: [3.9]
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out github
         uses: actions/checkout@v2
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install cmdstanpy for cmdstan install
         run: |
           pip install cmdstanpy
@@ -39,7 +41,7 @@ jobs:
 
       - name: Install CmdStan
         run: |
-          python -m cmdstanpy.install_cmdstan --version "${{ env.CMDSTAN_VERSION }}" --cores 2
+          python -m cmdstanpy.install_cmdstan --version "${{ env.CMDSTAN_VERSION }}" --cores 2 --verbose
 
       # we use the cache here to build the Stan models once for multiple interfaces
       - name: Set up test model cache
@@ -104,7 +106,6 @@ jobs:
         run: |
           cd python/
           pytest -v
-
 
   test_julia_client:
     needs: [build_test_models]
@@ -174,4 +175,53 @@ jobs:
         run: |
           cd R/tests/
           gcc -fpic -shared -o test_collisions.so test_collisions.c
+          Rscript test_bridgestan.R
+
+  # Seperate for now, weird dynamic linking issues need resolving in GHA runner
+  test_clients_windows:
+    needs: [build_test_models]
+    runs-on: windows-latest
+    steps:
+      - name: Check out github
+        uses: actions/checkout@v2
+
+      - name: Restore CmdStan
+        uses: actions/cache@v2
+        with:
+          path: ~/.cmdstan
+          key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
+
+      - name: Setup TBB
+        run: |
+          cd ~/.cmdstan/cmdstan-${{ env.CMDSTAN_VERSION }}
+          Add-Content $env:GITHUB_PATH "$(pwd)/stan/lib/stan_math/lib/tbb"
+
+      - name: Restore built models
+        uses: actions/cache@v2
+        id: test-models
+        with:
+          path: ./stan/
+          key: ${{ hashFiles('**/*.stan', 'src/*') }}-windows-latest-cmdstan-${{ env.CMDSTAN_VERSION }}-v${{ env.CACHE_VERSION }}
+
+      - name: Install R
+        uses: r-lib/actions/setup-r@v2
+
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::R6
+            any::testthat
+
+      - name: Set up Julia
+        uses: julia-actions/setup-julia@v1
+
+      - name: Run Julia tests
+        run: |
+          julia --project=./julia -t 2 -e "using Pkg; Pkg.test()"
+
+      - name: Run R tests
+        run: |
+          cd R/tests/
+          gcc -fpic -shared -o test_collisions.dll test_collisions.c
           Rscript test_bridgestan.R

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,9 +39,15 @@ jobs:
           path: ~/.cmdstan
           key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
 
-      - name: Install CmdStan
+      - name: Install CmdStan (Unix)
+        if: matrix.os != 'windows-latest'
         run: |
           python -m cmdstanpy.install_cmdstan --version "${{ env.CMDSTAN_VERSION }}" --cores 2 --verbose
+
+      - name: Install CmdStan (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          python -m cmdstanpy.install_cmdstan --version "${{ env.CMDSTAN_VERSION }}" --cores 2 --verbose --compiler
 
       # we use the cache here to build the Stan models once for multiple interfaces
       - name: Set up test model cache

--- a/R/bridgestan.R
+++ b/R/bridgestan.R
@@ -4,7 +4,7 @@ StanModel <- R6::R6Class("StanModel",
     initialize = function(lib, data, rng_seed, chain_id) {
       if (.Platform$OS.type == "windows"){
         lib_old <- lib
-        lib <- paste(tools::file_path_sans_ext(lib), ".dll")
+        lib <- paste0(tools::file_path_sans_ext(lib), ".dll")
         file.copy(from=lib_old, to=lib)
       }
 

--- a/stan/build_all.ps1
+++ b/stan/build_all.ps1
@@ -4,8 +4,5 @@ $models = "throw_tp",  "throw_gq",  "throw_lp",  "throw_data",  "jacobian",  "ma
 
 $cmdstanfixed = $env:CMDSTAN.replace('\', '/')
 foreach ($model in $models) {
-    mingw32-make.exe CMDSTAN="$($cmdstanfixed)/" -j4 O=0 "stan/$($model)/$($model)_model.so"
+    mingw32-make.exe CMDSTAN="$($cmdstanfixed)/" STAN_THREADS="True" -j4 O=0 "stan/$($model)/$($model)_model.so"
 }
-
-cd "$($env:BRIDGESTAN)/R/test"
-gcc.exe -fpic -shared -o test_collisions.dll test_collisions.c


### PR DESCRIPTION
This PR adds CI for the Julia and R client on Windows. Since #12, the Julia client alone should be enough to make sure we don't have any major regressions, but the R client has some Windows-specific things which are good to test as well. 

The Python client seems to have difficulty with the complex environment in the Github Actions runner (I have counted 5+ libgcc installs - _so far_) and fails to load. I think it's probably solvable (I have two separate Windows machines that it does work on), but for now I figured it was better to have some testing rather than wait. 