### PR TITLE
Add Julia doc and automated Documenter -> Sphinx pipeline

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,12 +32,15 @@ jobs:
       - name: Install dependencies (python)
         run: |
           python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade "sphinx>5" nbsphinx ipython ipykernel ipywidgets pydata-sphinx-theme
+          python -m pip install --upgrade "sphinx>5" nbsphinx ipython ipykernel ipywidgets pydata-sphinx-theme myst-parser
 
       - name: Install os dependencies
         run: |
           sudo apt-get update -y
           sudo apt-get install pandoc -y
+
+      - name: Set up Julia
+        uses: julia-actions/setup-julia@v1
 
       - name: CmdStan installation cacheing
         id: cmdstan-cache
@@ -60,9 +63,7 @@ jobs:
       - name: Build docs
         run: |
           cd python/docs/
-
           make html
-
           cd _build/html
 
           git init

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ _build/
 
 # Julia
 .juliahistory
+build/
 
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ We follow the practices laid out in the [GitHub Terms of Service](https://docs.g
 
 We follow standard open source and GitHub practices:
 
-* We discuss bugs, features, and implementations through [GitHub Issues](https://github.com/roualdes/bridgestan/issues). 
+* We discuss bugs, features, and implementations through [GitHub Issues](https://github.com/roualdes/bridgestan/issues).
 
 * We add unit tests when changing or adding code.
 
@@ -33,11 +33,12 @@ We follow standard open source and GitHub practices:
 
 We use [Sphinx](https://www.sphinx-doc.org/en/master/) to generate documentation, with the goal of publishing on [Read the Docs](https://readthedocs.org) for the first release.  The docs are currently hosted on the [GitHub pages](https://roualdes.github.io/bridgestan/) for this repository.
 
-We use the following developer-specific tools for documentation. 
+We use the following developer-specific tools for documentation.
 
-* [Sphinx 5.0 or above](https://www.sphinx-doc.org/en/master/) 
-* [nbsphinx](https://nbsphinx.readthedocs.io/en/0.8.9/) 
-* [pydata-sphinx-theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/) 
+* [Sphinx 5.0 or above](https://www.sphinx-doc.org/en/master/)
+* [nbsphinx](https://nbsphinx.readthedocs.io/en/0.8.9/)
+* [pydata-sphinx-theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/)
+* [MySt-Parser](https://myst-parser.readthedocs.io/en/latest/)
 
 
 ## Builds
@@ -65,7 +66,7 @@ We use [Gnu make](https://www.gnu.org/software/make/) for builds.  If you have i
 ### Python development
 
 * Python development relies on the external dependencies:
-    * [pytest](https://docs.pytest.org/en/7.1.x/) 
+    * [pytest](https://docs.pytest.org/en/7.1.x/)
     * [NumPy](https://numpy.org/)
 
 * We integrate a C wrapper of Stan's model class using the [ctypes](https://docs.python.org/3/library/ctypes.html) foreign function interface.

--- a/julia/docs/Manifest.toml
+++ b/julia/docs/Manifest.toml
@@ -1,0 +1,104 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.8.0"
+manifest_format = "2.0"
+project_hash = "68d108abde6d4526329eadc1b777c3f9b32e977e"
+
+[[deps.ANSIColoredPrinters]]
+git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
+uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
+version = "0.0.1"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "5158c2b41018c5f7eb1470d558127ac274eca0c9"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.1"
+
+[[deps.Documenter]]
+deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "6030186b00a38e9d0434518627426570aac2ef95"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.27.23"
+
+[[deps.DocumenterMarkdown]]
+deps = ["Documenter"]
+git-tree-sha1 = "9af057a98652336e30586d8092fac06f8b28ecdc"
+uuid = "997ab1e6-3595-5248-9280-8efb232c3433"
+version = "0.2.2"
+
+[[deps.IOCapture]]
+deps = ["Logging", "Random"]
+git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.2.2"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.3"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "3d5bf43e3e8b412656404ed9466f1dcbf7c50269"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.4.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/julia/docs/Project.toml
+++ b/julia/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"

--- a/julia/docs/README.md
+++ b/julia/docs/README.md
@@ -1,0 +1,4 @@
+# Julia Interface Docs
+
+We use [DocumenterMarkdown.jl](https://github.com/JuliaDocs/DocumenterMarkdown.jl) to build documentation
+from our source file. This is then copied into the Python docs source tree for use by Sphinx.

--- a/julia/docs/make.jl
+++ b/julia/docs/make.jl
@@ -1,0 +1,7 @@
+using Documenter, BridgeStan
+using DocumenterMarkdown
+
+makedocs(format=Markdown())
+
+cp(joinpath(@__DIR__, "build/julia.md"), joinpath(@__DIR__, "../../python/docs/languages/julia.md"); force=true)
+cp(joinpath(@__DIR__, "build/assets/Documenter.css"), joinpath(@__DIR__, "../../python/docs/_static/css/Documenter.css"); force=true)

--- a/julia/docs/make.jl
+++ b/julia/docs/make.jl
@@ -1,7 +1,15 @@
 using Documenter, BridgeStan
 using DocumenterMarkdown
 
-makedocs(format=Markdown())
+makedocs(format = Markdown())
 
-cp(joinpath(@__DIR__, "build/julia.md"), joinpath(@__DIR__, "../../python/docs/languages/julia.md"); force=true)
-cp(joinpath(@__DIR__, "build/assets/Documenter.css"), joinpath(@__DIR__, "../../python/docs/_static/css/Documenter.css"); force=true)
+cp(
+    joinpath(@__DIR__, "build/julia.md"),
+    joinpath(@__DIR__, "../../python/docs/languages/julia.md");
+    force = true,
+)
+cp(
+    joinpath(@__DIR__, "build/assets/Documenter.css"),
+    joinpath(@__DIR__, "../../python/docs/_static/css/Documenter.css");
+    force = true,
+)

--- a/julia/docs/src/julia.md
+++ b/julia/docs/src/julia.md
@@ -1,4 +1,4 @@
-# Julia Interface: bridgestan.jl
+# Julia Interface: BridgeStan.jl
 
 % NB: This file is generated from the one in julia/docs/src/julia.md
 

--- a/julia/docs/src/julia.md
+++ b/julia/docs/src/julia.md
@@ -1,0 +1,8 @@
+# Julia Interface: bridgestan.jl
+
+% NB: This file is generated from the one in julia/docs/src/julia.md
+
+```@autodocs
+Modules = [BridgeStan]
+Order   = [:type, :function]
+```

--- a/julia/docs/src/julia.md
+++ b/julia/docs/src/julia.md
@@ -2,7 +2,23 @@
 
 % NB: This file is generated from the one in julia/docs/src/julia.md
 
-```@autodocs
-Modules = [BridgeStan]
-Order   = [:type, :function]
+
+```@docs
+StanModel
+log_density
+log_density_gradient
+log_density_hessian
+param_constrain
+param_unconstrain
+param_unconstrain_json
+name
+param_num
+param_unc_num
+param_names
+param_unc_names
+log_density_gradient!
+log_density_hessian!
+param_constrain!
+param_unconstrain!
+param_unconstrain_json!
 ```

--- a/julia/docs/src/julia.md
+++ b/julia/docs/src/julia.md
@@ -1,7 +1,11 @@
 # Julia Interface: BridgeStan.jl
 
-% NB: This file is generated from the one in julia/docs/src/julia.md
-
+```@raw html
+% NB: If you are reading this file in python/docs/languages, you are reading a generated output!
+% This should be apparent due to the html tags everywhere.
+% If you are reading this in julia/docs/src, you are reading the true source!
+% Please only make edits in the later file, since the first is DELETED each re-build.
+```
 
 ```@docs
 StanModel

--- a/julia/src/BridgeStan.jl
+++ b/julia/src/BridgeStan.jl
@@ -35,7 +35,7 @@ mutable struct StanModel
     const seed::UInt32
     const chain_id::UInt32
 
-    function StanModel(stanlib_::String, datafile_::String="", seed_=204, chain_id_=0)
+    function StanModel(stanlib_::String, datafile_::String = "", seed_ = 204, chain_id_ = 0)
         seed = convert(UInt32, seed_)
         chain_id = convert(UInt32, chain_id_)
 
@@ -101,7 +101,7 @@ of the model. If `include_tp` or `include_gq` are true, items declared
 in the `transformed parameters` and `generate quantities` blocks are included,
 respectively.
 """
-function param_num(sm::StanModel; include_tp=false, include_gq=false)
+function param_num(sm::StanModel; include_tp = false, include_gq = false)
     ccall(
         Libc.Libdl.dlsym(sm.lib, "param_num"),
         Cint,
@@ -131,7 +131,7 @@ function param_unc_num(sm::StanModel)
     )
 end
 
-function param_names(sm::StanModel; include_tp=false, include_gq=false)
+function param_names(sm::StanModel; include_tp = false, include_gq = false)
     cstr = ccall(
         Libc.Libdl.dlsym(sm.lib, "param_names"),
         Cstring,
@@ -157,10 +157,10 @@ function param_constrain!(
     sm::StanModel,
     theta_unc::Vector{Float64},
     out::Vector{Float64};
-    include_tp=false,
-    include_gq=false
+    include_tp = false,
+    include_gq = false,
 )
-    dims = param_num(sm; include_tp=include_tp, include_gq=include_gq)
+    dims = param_num(sm; include_tp = include_tp, include_gq = include_gq)
     if length(out) != dims
         throw(
             DimensionMismatch("out must be same size as number of constrained parameters"),
@@ -185,11 +185,11 @@ end
 function param_constrain(
     sm::StanModel,
     theta_unc::Vector{Float64};
-    include_tp=false,
-    include_gq=false
+    include_tp = false,
+    include_gq = false,
 )
-    out = zeros(param_num(sm, include_tp=include_tp, include_gq=include_gq))
-    param_constrain!(sm, theta_unc, out; include_tp=include_tp, include_gq=include_gq)
+    out = zeros(param_num(sm, include_tp = include_tp, include_gq = include_gq))
+    param_constrain!(sm, theta_unc, out; include_tp = include_tp, include_gq = include_gq)
 end
 
 
@@ -251,7 +251,7 @@ function param_unconstrain_json(sm::StanModel, theta::String)
     param_unconstrain_json!(sm, theta, out)
 end
 
-function log_density(sm::StanModel, q::Vector{Float64}; propto=true, jacobian=true)
+function log_density(sm::StanModel, q::Vector{Float64}; propto = true, jacobian = true)
     lp = Ref(0.0)
     rc = ccall(
         Libc.Libdl.dlsym(sm.lib, "log_density"),
@@ -273,8 +273,8 @@ function log_density_gradient!(
     sm::StanModel,
     q::Vector{Float64},
     out::Vector{Float64};
-    propto=true,
-    jacobian=true
+    propto = true,
+    jacobian = true,
 )
     lp = Ref(0.0)
     dims = param_unc_num(sm)
@@ -306,11 +306,11 @@ end
 function log_density_gradient(
     sm::StanModel,
     q::Vector{Float64};
-    propto=true,
-    jacobian=true
+    propto = true,
+    jacobian = true,
 )
     grad = zeros(param_unc_num(sm))
-    log_density_gradient!(sm, q, grad; propto=propto, jacobian=jacobian)
+    log_density_gradient!(sm, q, grad; propto = propto, jacobian = jacobian)
 end
 
 function log_density_hessian!(
@@ -318,8 +318,8 @@ function log_density_hessian!(
     q::Vector{Float64},
     out_grad::Vector{Float64},
     out_hess::Vector{Float64};
-    propto=true,
-    jacobian=true
+    propto = true,
+    jacobian = true,
 )
     lp = Ref(0.0)
     dims = param_unc_num(sm)
@@ -367,13 +367,13 @@ end
 function log_density_hessian(
     sm::StanModel,
     q::Vector{Float64};
-    propto=true,
-    jacobian=true
+    propto = true,
+    jacobian = true,
 )
     dims = param_unc_num(sm)
     grad = zeros(dims)
     hess = zeros(dims * dims)
-    log_density_hessian!(sm, q, grad, hess; propto=propto, jacobian=jacobian)
+    log_density_hessian!(sm, q, grad, hess; propto = propto, jacobian = jacobian)
 end
 
 end

--- a/python/docs/_static/css/Documenter.css
+++ b/python/docs/_static/css/Documenter.css
@@ -1,0 +1,18 @@
+div.wy-menu-vertical ul.current li.toctree-l3 a {
+  font-weight: bold;
+}
+
+a.documenter-source {
+  float: right;
+}
+
+.documenter-methodtable pre {
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: 0;
+    padding: 0;
+}
+
+.documenter-methodtable pre.documenter-inline {
+    display: inline;
+}

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -22,6 +22,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "nbsphinx",
     "sphinx.ext.mathjax",
+    "myst_parser",
 ]
 
 templates_path = ["_templates"]
@@ -33,6 +34,10 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+html_css_files = [
+    "css/Documenter.css",
+]
+
 html_show_sphinx = False
 
 html_theme_options = {
@@ -67,3 +72,17 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "cmdstanpy": ("https://mc-stan.org/cmdstanpy/", None),
 }
+
+# julia doc build
+import subprocess
+import pathlib
+
+try:
+    print("Building Julia doc")
+    subprocess.run(
+        ["julia", "--project", "make.jl"],
+        cwd=pathlib.Path(__file__).parent.parent.parent / "julia" / "docs",
+        check=True,
+    )
+except Exception as e:
+    print("Failed to build julia docs!\n", e)

--- a/python/docs/languages/julia.md
+++ b/python/docs/languages/julia.md
@@ -22,10 +22,118 @@ A StanModel instance encapsulates a Stan model instantiated with data.
 The constructor a Stan model from the supplied library file path and data file path. If seed or chain_id are supplied, these are used to initialize the RNG used by the model.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/b663d2c04fecb2d99dd35c4c7f5008c42c6b4346/julia/src/BridgeStan.jl#L23-L30' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L23-L30' class='documenter-source'>source</a><br>
 
-<a id='BridgeStan.name-Tuple{StanModel}' href='#BridgeStan.name-Tuple{StanModel}'>#</a>
-**`BridgeStan.name`** &mdash; *Method*.
+<a id='BridgeStan.log_density' href='#BridgeStan.log_density'>#</a>
+**`BridgeStan.log_density`** &mdash; *Function*.
+
+
+
+```julia
+log_density(sm, q; propto=true, jacobian=true)
+```
+
+Return the log density of the specified unconstrained parameters.
+
+This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L346-L353' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.log_density_gradient' href='#BridgeStan.log_density_gradient'>#</a>
+**`BridgeStan.log_density_gradient`** &mdash; *Function*.
+
+
+
+```julia
+log_density_gradient(sm, q; propto=true, jacobian=true)
+```
+
+Returns a tuple of the log density and gradient of the specified unconstrained parameters.
+
+This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
+
+This allocates new memory for the gradient output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L418-L430' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.log_density_hessian' href='#BridgeStan.log_density_hessian'>#</a>
+**`BridgeStan.log_density_hessian`** &mdash; *Function*.
+
+
+
+```julia
+log_density_hessian(sm, q; propto=true, jacobian=true)
+```
+
+Returns a tuple of the log density, gradient, and Hessian  of the specified unconstrained parameters.
+
+This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
+
+This allocates new memory for the gradient and Hessian output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L504-L515' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.param_constrain' href='#BridgeStan.param_constrain'>#</a>
+**`BridgeStan.param_constrain`** &mdash; *Function*.
+
+
+
+```julia
+param_constrain(sm, theta_unc, out; include_tp=false, include_gq=false)
+```
+
+This turns a vector of unconstrained params into constrained parameters and (if `include_tp` and `include_gq` are set, respectively) transformed parameters and generated quantities.
+
+This allocates new memory for the output each call. See `param_constrain!` for a version which allows re-using existing memory.
+
+This is the inverse of `param_unconstrain`.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L217-L229' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.param_unconstrain' href='#BridgeStan.param_unconstrain'>#</a>
+**`BridgeStan.param_unconstrain`** &mdash; *Function*.
+
+
+
+```julia
+param_unconstrain(sm, theta)
+```
+
+This turns a vector of constrained params into unconstrained parameters.
+
+It is assumed that these will be in the same order as internally represented by the model (e.g., in the same order as `param_unc_names(sm)`). If structured input is needed, use `param_unconstrain_json`
+
+This allocates new memory for the output each call. See `param_unconstrain!` for a version which allows re-using existing memory.
+
+This is the inverse of `param_constrain`.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L277-L290' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.param_unconstrain_json' href='#BridgeStan.param_unconstrain_json'>#</a>
+**`BridgeStan.param_unconstrain_json`** &mdash; *Function*.
+
+
+
+```julia
+param_unconstrain_json(sm, theta)
+```
+
+This accepts a JSON string of constrained parameters and returns the unconstrained parameters.
+
+The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/docs/cmdstan-guide/json.html).
+
+This allocates new memory for the output each call. See `param_unconstrain_json!` for a version which allows re-using existing memory.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L330-L340' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.name' href='#BridgeStan.name'>#</a>
+**`BridgeStan.name`** &mdash; *Function*.
 
 
 
@@ -36,10 +144,10 @@ name(sm)
 Return the name of the model `sm`
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/b663d2c04fecb2d99dd35c4c7f5008c42c6b4346/julia/src/BridgeStan.jl#L79-L83' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L79-L83' class='documenter-source'>source</a><br>
 
-<a id='BridgeStan.param_num-Tuple{StanModel}' href='#BridgeStan.param_num-Tuple{StanModel}'>#</a>
-**`BridgeStan.param_num`** &mdash; *Method*.
+<a id='BridgeStan.param_num' href='#BridgeStan.param_num'>#</a>
+**`BridgeStan.param_num`** &mdash; *Function*.
 
 
 
@@ -52,10 +160,10 @@ Return the number of (constrained) parameters in the model.
 This is the total of all the sizes of items declared in the `parameters` block of the model. If `include_tp` or `include_gq` are true, items declared in the `transformed parameters` and `generate quantities` blocks are included, respectively.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/b663d2c04fecb2d99dd35c4c7f5008c42c6b4346/julia/src/BridgeStan.jl#L94-L103' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L94-L103' class='documenter-source'>source</a><br>
 
-<a id='BridgeStan.param_unc_num-Tuple{StanModel}' href='#BridgeStan.param_unc_num-Tuple{StanModel}'>#</a>
-**`BridgeStan.param_unc_num`** &mdash; *Method*.
+<a id='BridgeStan.param_unc_num' href='#BridgeStan.param_unc_num'>#</a>
+**`BridgeStan.param_unc_num`** &mdash; *Function*.
 
 
 
@@ -68,5 +176,131 @@ Return the number of unconstrained parameters in the model.
 This function is mainly different from `param_num` when variables are declared with constraints. For example, `simplex[5]` has a constrained size of 5, but an unconstrained size of 4.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/b663d2c04fecb2d99dd35c4c7f5008c42c6b4346/julia/src/BridgeStan.jl#L116-L124' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L116-L124' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.param_names' href='#BridgeStan.param_names'>#</a>
+**`BridgeStan.param_names`** &mdash; *Function*.
+
+
+
+```julia
+param_names(sm; include_tp=false, include_gq=false)
+```
+
+Return the indexed names of the (constrained) parameters, including transformed parameters and/or generated quantities as indicated.
+
+For containers, indexes are separated by periods (.).
+
+For example, the scalar `a` has indexed name `"a"`, the vector entry `a[1]` has indexed name `"a.1"` and the matrix entry `a[2, 3]` has indexed names `"a.2.3"`. Parameter order of the output is column major and more generally last-index major for containers.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L134-L145' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.param_unc_names' href='#BridgeStan.param_unc_names'>#</a>
+**`BridgeStan.param_unc_names`** &mdash; *Function*.
+
+
+
+```julia
+param_unc_names(sm)
+```
+
+Return the indexed names of the unconstrained parameters.
+
+For example, a scalar unconstrained parameter `b` has indexed name `b` and a vector entry `b[3]` has indexed name `b.3`.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L158-L165' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.log_density_gradient!' href='#BridgeStan.log_density_gradient!'>#</a>
+**`BridgeStan.log_density_gradient!`** &mdash; *Function*.
+
+
+
+```julia
+log_density_gradient!(sm, q, out; propto=true, jacobian=true)
+```
+
+Returns a tuple of the log density and gradient of the specified unconstrained parameters.
+
+This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
+
+The gradient is stored in the vector `out`, and a reference is returned. See `log_density_gradient` for a version which allocates fresh memory.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L373-L383' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.log_density_hessian!' href='#BridgeStan.log_density_hessian!'>#</a>
+**`BridgeStan.log_density_hessian!`** &mdash; *Function*.
+
+
+
+```julia
+log_density_hessian!(sm, q, out_grad, out_hess; propto=true, jacobian=true)
+```
+
+Returns a tuple of the log density, gradient, and Hessian  of the specified unconstrained parameters.
+
+This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
+
+The gradient is stored in the vector `out_grad` and the Hessian is stored in `out_hess` and references are returned. See `log_density_hessian` for a version which allocates fresh memory.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L441-L452' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.param_constrain!' href='#BridgeStan.param_constrain!'>#</a>
+**`BridgeStan.param_constrain!`** &mdash; *Function*.
+
+
+
+```julia
+param_constrain!(sm, theta_unc, out; include_tp=false, include_gq=false)
+```
+
+This turns a vector of unconstrained params into constrained parameters and (if `include_tp` and `include_gq` are set, respectively) transformed parameters and generated quantities.
+
+The result is stored in the vector `out`, and a reference is returned. See `param_constrain` for a version which allocates fresh memory.
+
+This is the inverse of `param_unconstrain!`.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L176-L187' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.param_unconstrain!' href='#BridgeStan.param_unconstrain!'>#</a>
+**`BridgeStan.param_unconstrain!`** &mdash; *Function*.
+
+
+
+```julia
+param_unconstrain!(sm, theta, out)
+```
+
+This turns a vector of constrained params into unconstrained parameters.
+
+It is assumed that these will be in the same order as internally represented by the model (e.g., in the same order as `param_unc_names(sm)`). If structured input is needed, use `param_unconstrain_json!`
+
+The result is stored in the vector `out`, and a reference is returned. See `param_unconstrain` for a version which allocates fresh memory.
+
+This is the inverse of `param_constrain!`.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L240-L252' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.param_unconstrain_json!' href='#BridgeStan.param_unconstrain_json!'>#</a>
+**`BridgeStan.param_unconstrain_json!`** &mdash; *Function*.
+
+
+
+```julia
+param_unconstrain_json!(sm, theta, out)
+```
+
+This accepts a JSON string of constrained parameters and returns the unconstrained parameters.
+
+The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/docs/cmdstan-guide/json.html).
+
+The result is stored in the vector `out`, and a reference is returned. See `param_unconstrain_json` for a version which allocates fresh memory.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L296-L305' class='documenter-source'>source</a><br>
 

--- a/python/docs/languages/julia.md
+++ b/python/docs/languages/julia.md
@@ -1,0 +1,72 @@
+
+<a id='Julia-Interface:-bridgestan.jl'></a>
+
+<a id='Julia-Interface:-bridgestan.jl-1'></a>
+
+# Julia Interface: bridgestan.jl
+
+
+% NB: This file is generated from the one in julia/docs/src/julia.md
+
+<a id='BridgeStan.StanModel' href='#BridgeStan.StanModel'>#</a>
+**`BridgeStan.StanModel`** &mdash; *Type*.
+
+
+
+```julia
+StanModel(stanlib_, datafile_="", seed_=204, chain_id_=0)
+```
+
+A StanModel instance encapsulates a Stan model instantiated with data.
+
+The constructor a Stan model from the supplied library file path and data file path. If seed or chain_id are supplied, these are used to initialize the RNG used by the model.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/b663d2c04fecb2d99dd35c4c7f5008c42c6b4346/julia/src/BridgeStan.jl#L23-L30' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.name-Tuple{StanModel}' href='#BridgeStan.name-Tuple{StanModel}'>#</a>
+**`BridgeStan.name`** &mdash; *Method*.
+
+
+
+```julia
+name(sm)
+```
+
+Return the name of the model `sm`
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/b663d2c04fecb2d99dd35c4c7f5008c42c6b4346/julia/src/BridgeStan.jl#L79-L83' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.param_num-Tuple{StanModel}' href='#BridgeStan.param_num-Tuple{StanModel}'>#</a>
+**`BridgeStan.param_num`** &mdash; *Method*.
+
+
+
+```julia
+param_num(sm; include_tp=false, include_gq=false)
+```
+
+Return the number of (constrained) parameters in the model.
+
+This is the total of all the sizes of items declared in the `parameters` block of the model. If `include_tp` or `include_gq` are true, items declared in the `transformed parameters` and `generate quantities` blocks are included, respectively.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/b663d2c04fecb2d99dd35c4c7f5008c42c6b4346/julia/src/BridgeStan.jl#L94-L103' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.param_unc_num-Tuple{StanModel}' href='#BridgeStan.param_unc_num-Tuple{StanModel}'>#</a>
+**`BridgeStan.param_unc_num`** &mdash; *Method*.
+
+
+
+```julia
+param_unc_num(sm)
+```
+
+Return the number of unconstrained parameters in the model.
+
+This function is mainly different from `param_num` when variables are declared with constraints. For example, `simplex[5]` has a constrained size of 5, but an unconstrained size of 4.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/b663d2c04fecb2d99dd35c4c7f5008c42c6b4346/julia/src/BridgeStan.jl#L116-L124' class='documenter-source'>source</a><br>
+

--- a/python/docs/languages/julia.md
+++ b/python/docs/languages/julia.md
@@ -1,12 +1,15 @@
 
-<a id='Julia-Interface:-bridgestan.jl'></a>
+<a id='Julia-Interface:-BridgeStan.jl'></a>
 
-<a id='Julia-Interface:-bridgestan.jl-1'></a>
+<a id='Julia-Interface:-BridgeStan.jl-1'></a>
 
-# Julia Interface: bridgestan.jl
+# Julia Interface: BridgeStan.jl
 
 
-% NB: This file is generated from the one in julia/docs/src/julia.md
+% NB: If you are reading this file in python/docs/languages, you are reading a generated output!
+% This should be apparent due to the html tags everywhere.
+% If you are reading this in julia/docs/src, you are reading the true source!
+% Please only make edits in the later file, since the first is DELETED each re-build.
 
 <a id='BridgeStan.StanModel' href='#BridgeStan.StanModel'>#</a>
 **`BridgeStan.StanModel`** &mdash; *Type*.
@@ -22,7 +25,7 @@ A StanModel instance encapsulates a Stan model instantiated with data.
 The constructor a Stan model from the supplied library file path and data file path. If seed or chain_id are supplied, these are used to initialize the RNG used by the model.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L23-L30' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L23-L30' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density' href='#BridgeStan.log_density'>#</a>
 **`BridgeStan.log_density`** &mdash; *Function*.
@@ -38,7 +41,7 @@ Return the log density of the specified unconstrained parameters.
 This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L346-L353' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L346-L353' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient' href='#BridgeStan.log_density_gradient'>#</a>
 **`BridgeStan.log_density_gradient`** &mdash; *Function*.
@@ -56,7 +59,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L418-L430' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L418-L430' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian' href='#BridgeStan.log_density_hessian'>#</a>
 **`BridgeStan.log_density_hessian`** &mdash; *Function*.
@@ -74,7 +77,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient and Hessian output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L504-L515' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L504-L515' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain' href='#BridgeStan.param_constrain'>#</a>
 **`BridgeStan.param_constrain`** &mdash; *Function*.
@@ -92,7 +95,7 @@ This allocates new memory for the output each call. See `param_constrain!` for a
 This is the inverse of `param_unconstrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L217-L229' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L217-L229' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain' href='#BridgeStan.param_unconstrain'>#</a>
 **`BridgeStan.param_unconstrain`** &mdash; *Function*.
@@ -112,7 +115,7 @@ This allocates new memory for the output each call. See `param_unconstrain!` for
 This is the inverse of `param_constrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L277-L290' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L277-L290' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json' href='#BridgeStan.param_unconstrain_json'>#</a>
 **`BridgeStan.param_unconstrain_json`** &mdash; *Function*.
@@ -130,7 +133,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 This allocates new memory for the output each call. See `param_unconstrain_json!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L330-L340' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L330-L340' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.name' href='#BridgeStan.name'>#</a>
 **`BridgeStan.name`** &mdash; *Function*.
@@ -144,7 +147,7 @@ name(sm)
 Return the name of the model `sm`
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L79-L83' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L79-L83' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_num' href='#BridgeStan.param_num'>#</a>
 **`BridgeStan.param_num`** &mdash; *Function*.
@@ -160,7 +163,7 @@ Return the number of (constrained) parameters in the model.
 This is the total of all the sizes of items declared in the `parameters` block of the model. If `include_tp` or `include_gq` are true, items declared in the `transformed parameters` and `generate quantities` blocks are included, respectively.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L94-L103' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L94-L103' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_num' href='#BridgeStan.param_unc_num'>#</a>
 **`BridgeStan.param_unc_num`** &mdash; *Function*.
@@ -176,7 +179,7 @@ Return the number of unconstrained parameters in the model.
 This function is mainly different from `param_num` when variables are declared with constraints. For example, `simplex[5]` has a constrained size of 5, but an unconstrained size of 4.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L116-L124' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L116-L124' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_names' href='#BridgeStan.param_names'>#</a>
 **`BridgeStan.param_names`** &mdash; *Function*.
@@ -194,7 +197,7 @@ For containers, indexes are separated by periods (.).
 For example, the scalar `a` has indexed name `"a"`, the vector entry `a[1]` has indexed name `"a.1"` and the matrix entry `a[2, 3]` has indexed names `"a.2.3"`. Parameter order of the output is column major and more generally last-index major for containers.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L134-L145' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L134-L145' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_names' href='#BridgeStan.param_unc_names'>#</a>
 **`BridgeStan.param_unc_names`** &mdash; *Function*.
@@ -210,7 +213,7 @@ Return the indexed names of the unconstrained parameters.
 For example, a scalar unconstrained parameter `b` has indexed name `b` and a vector entry `b[3]` has indexed name `b.3`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L158-L165' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L158-L165' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient!' href='#BridgeStan.log_density_gradient!'>#</a>
 **`BridgeStan.log_density_gradient!`** &mdash; *Function*.
@@ -228,7 +231,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out`, and a reference is returned. See `log_density_gradient` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L373-L383' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L373-L383' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian!' href='#BridgeStan.log_density_hessian!'>#</a>
 **`BridgeStan.log_density_hessian!`** &mdash; *Function*.
@@ -246,7 +249,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out_grad` and the Hessian is stored in `out_hess` and references are returned. See `log_density_hessian` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L441-L452' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L441-L452' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain!' href='#BridgeStan.param_constrain!'>#</a>
 **`BridgeStan.param_constrain!`** &mdash; *Function*.
@@ -264,7 +267,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_unconstrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L176-L187' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L176-L187' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain!' href='#BridgeStan.param_unconstrain!'>#</a>
 **`BridgeStan.param_unconstrain!`** &mdash; *Function*.
@@ -284,7 +287,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_constrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L240-L252' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L240-L252' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json!' href='#BridgeStan.param_unconstrain_json!'>#</a>
 **`BridgeStan.param_unconstrain_json!`** &mdash; *Function*.
@@ -302,5 +305,5 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 The result is stored in the vector `out`, and a reference is returned. See `param_unconstrain_json` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/753bd3169bebfa0440f0dcd4c06cf2439c253534/julia/src/BridgeStan.jl#L296-L305' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/888433c44697bc7076cd1fa1d9f4995da20dd82c/julia/src/BridgeStan.jl#L296-L305' class='documenter-source'>source</a><br>
 

--- a/python/docs/languages/julia.rst
+++ b/python/docs/languages/julia.rst
@@ -1,4 +1,0 @@
-Julia Interface: bridgestan.jl
-==============================
-
-API doc will go here.


### PR DESCRIPTION
This was discussed in the comments of #7.

This uses `DocumenterMarkdown` to build a Markdown version of the Julia docs and embeds it in Sphinx. The output is not quite as pretty as Python's, but I think it's not too bad:

![image](https://user-images.githubusercontent.com/31640292/190216332-763e20ab-ee11-4e9c-a1b8-98fdad3e2847.png)


If you don't have Julia installed, I am assuming you're not updating the Julia docs, so it will ignore the error and proceed. 