### PR TITLE
Add example of calling from C

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,6 +49,20 @@ jobs:
         run: |
           python -m cmdstanpy.install_cmdstan --version "${{ env.CMDSTAN_VERSION }}" --cores 2 --verbose --compiler
 
+      - name: Build C example (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          export CMDSTAN=$(python -c "import cmdstanpy; print(cmdstanpy.cmdstan_path())")/
+          cd c-example/
+          make example
+          make example_static
+          rm ../src/bridgestan.o
+          rm ../stan/full/full_model.a
+
+          ./example
+          ./example_static
+        shell: bash
+
       # we use the cache here to build the Stan models once for multiple interfaces
       - name: Set up test model cache
         uses: actions/cache@v2
@@ -72,6 +86,7 @@ jobs:
           $env:CMDSTAN = $(python -c "import cmdstanpy; print(cmdstanpy.cmdstan_path())")
           ./stan/build_all.ps1
         shell: pwsh
+
 
   test_python_client:
     needs: [build_test_models]

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 *.so
 *.hpp
 *.dll
+*.a
+c-example/example
+c-example/example_static
+*.exe
 
 notes.org
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 STAN_FLAGS=$(STAN_FLAG_THREADS)$(STAN_FLAG_OPENCL)
 
 BRIDGE ?= src/bridgestan.cpp
-BRIDGE_SO = $(patsubst %.cpp,%$(STAN_FLAGS).so,$(BRIDGE))
+BRIDGE_O = $(patsubst %.cpp,%$(STAN_FLAGS).o,$(BRIDGE))
 
 $(STANC):
 	@echo 'stanc could not be found. Make sure CmdStan is installed and built, and that the path specificied is correct:'
@@ -46,7 +46,7 @@ $(STANC):
 
 ## COMPILE (e.g., COMPILE.cpp == clang++ ...) was set by (MATH)make/compiler_flags
 ## UNKNOWNS:  OUTPUT_OPTION???  LDLIBS???
-$(BRIDGE_SO) : $(BRIDGE)
+$(BRIDGE_O) : $(BRIDGE)
 	@echo ''
 	@echo '--- Compiling Stan bridge C++ code ---'
 	@mkdir -p $(dir $@)
@@ -65,12 +65,12 @@ $(BRIDGE_SO) : $(BRIDGE)
 .PRECIOUS: %.hpp
 
 ## builds executable (suffix depends on platform)
-%_model.so : %.hpp $(BRIDGE_SO) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
+%_model.so : %.hpp $(BRIDGE_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
 	@echo ''
 	@echo '--- Compiling C++ code ---'
 	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -fPIC $(CXXFLAGS_THREADS) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
 	@echo '--- Linking C++ code ---'
-	$(LINK.cpp) -shared -lm -fPIC -o $(patsubst %.hpp, %_model.so, $(subst \,/,$<)) $(subst \,/,$*.o) $(BRIDGE_SO) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
+	$(LINK.cpp) -shared -lm -fPIC -o $(patsubst %.hpp, %_model.so, $(subst \,/,$<)) $(subst \,/,$*.o) $(BRIDGE_O) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
 	$(RM) $(subst  \,/,$*).o
 
 ## calculate dependencies for %$(EXE) target
@@ -94,7 +94,7 @@ clean-deps:
 	$(RM) $(call findfiles,src,*.dSYM) $(call findfiles,src/stan,*.dSYM) $(call findfiles,$(MATH)/stan,*.dSYM)
 
 clean-all: clean clean-deps
-	$(RM) $(BRIDGE_SO)
+	$(RM) $(BRIDGE_O)
 	$(RM) -r $(wildcard $(BOOST)/stage/lib $(BOOST)/bin.v2 $(BOOST)/tools/build/src/engine/bootstrap/ $(BOOST)/tools/build/src/engine/bin.* $(BOOST)/project-config.jam* $(BOOST)/b2 $(BOOST)/bjam $(BOOST)/bootstrap.log)
 
 clean-program:
@@ -110,7 +110,7 @@ endif
 # print compilation command line config
 .PHONY: compile_info
 compile_info:
-	@echo '$(LINK.cpp) $(CXXFLAGS_PROGRAM) $(BRIDGE_SO) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)'
+	@echo '$(LINK.cpp) $(CXXFLAGS_PROGRAM) $(BRIDGE_O) $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)'
 
 ## print value of makefile variable (e.g., make print-TBB_TARGETS)
 .PHONY: print-%

--- a/c-example/Makefile
+++ b/c-example/Makefile
@@ -1,0 +1,27 @@
+# Tell the top-level makefile which relative path to use
+BRIDGE=../src/bridgestan.cpp
+include ../Makefile
+
+../stan/full/libfull_model.so: ../stan/full/full_model.so
+	cp ../stan/full/full_model.so ../stan/full/libfull_model.so
+
+example$(EXE): example.c ../stan/full/libfull_model.so
+	gcc -c -I ../src example.c -o example.o
+	$(LINK.c) -o example$(EXE) example.o -Wl,-rpath ../stan/full -L ../stan/full -lfull_model
+	$(RM) example.o
+
+# static linking version
+
+# this is very similar to the core Make rule in BridgeStan, just with AR instead of LINK
+%_model.a: %.hpp $(BRIDGE_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
+	@echo '--- Compiling C++ code ---'
+	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -fPIC $(CXXFLAGS_THREADS) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
+	@echo '--- Creating static library ---'
+	$(AR) -cvq $(patsubst %.hpp, %_model.a, $(subst \,/,$<)) $(subst \,/,$*.o) $(BRIDGE_O)
+	$(RM) $(subst  \,/,$*).o
+
+
+example_static$(EXE):  example.c ../stan/full/full_model.a
+	gcc -c -I ../src example.c -o example.o
+	$(LINK.cpp) -o example_static$(EXE) example.o ../stan/full/full_model.a $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
+	$(RM) example.o

--- a/c-example/README.md
+++ b/c-example/README.md
@@ -5,7 +5,7 @@ This shows how one could write a C program which calls BridgeStan.
 Any compiled language with a C foreign function interface and
 the ability to link against C libraries should be able to work similarly.
 
-## Usage - dynamic linking
+## Usage with dynamic linking
 
 It is possible to link against the same `name_model.so` object used by the other
 BridgeStan interfaces. This creates a dynamic link.
@@ -27,9 +27,10 @@ It has 1 parameters.
 The basic steps for using with a generic BridgeStan model are
 
 1. Include `bridgestan.h` in your source.
-2. At compile time, provide a path the model you need and link against it.
-   On some most platforms, this will require renaming to comply with certain naming
-   conventions. For example, `gcc` requires the library be prefixed with "lib".
+2. At compile time, provide a path to the folder containing the model you need,
+   and link against it. On most platforms, this will require renaming the shared object
+   file to comply with certain naming conventions. For example, `gcc` requires the library
+   be prefixed with "lib".
    The Makefile in this folder does that by making a copy.
 
 This dynamic linking will work on Windows, but Windows does not record the paths
@@ -39,7 +40,7 @@ in the same folder as the executable, or on your `PATH`.
 On all platforms, dynamic linking requires that the original `name_model.so` object
 still exist when the executable is run.
 
-## Usage - static linking
+## Usage with static linking
 
 The makefile here also shows how to create a `.a` static library using the BridgeStan
 source, and then compiling an executable which is independent of the location of the model.

--- a/c-example/README.md
+++ b/c-example/README.md
@@ -1,0 +1,54 @@
+# BridgeStan from C
+
+This shows how one could write a C program which calls BridgeStan.
+
+Any compiled language with a C foreign function interface should
+be able to work on a similar principal.
+
+## Usage - dynamic linking
+
+It is possible to link against the same `name_model.so` object used by the other
+BridgeStan interfaces. This creates a dynamic link.
+
+```shell
+make example
+./example
+```
+
+This should output:
+
+```
+This model's name is full_model.
+It has 1 parameters.
+```
+
+### Notes
+
+The basic steps for using with a generic BridgeStan model are
+
+1. Include `bridgestan.h` in your source.
+2. At compile time, provide a path the model you need and link against it.
+   On some most platforms, this will require renaming to comply with certain naming
+   conventions. For example, `gcc` requires the library be prefixed with "lib".
+   The Makefile in this folder does that by making a copy.
+
+This dynamic linking will work on Windows, but Windows does not record the paths
+of shared libraries in executables. As such, `full_model.so` will need to be
+in the same folder as the executable, or on your `PATH`.
+
+On all platforms, dynamic linking requires that the original `name_model.so` object
+still exist when the executable is run.
+
+## Usage - static linking
+
+The makefile here also shows how to create a `.a` static library using the BridgeStan
+source, and then compiling an executable which is independent of the location of the model.
+
+```shell
+make example_static
+rm ../stan/full/full_model.a # statically linked executable doesn't need library around
+./example_static
+```
+
+Will output the same as the above. Note that some Stan libraries such as TBB
+are still dynamically linked.

--- a/c-example/README.md
+++ b/c-example/README.md
@@ -2,8 +2,8 @@
 
 This shows how one could write a C program which calls BridgeStan.
 
-Any compiled language with a C foreign function interface should
-be able to work on a similar principal.
+Any compiled language with a C foreign function interface and
+the ability to link against C libraries should be able to work similarly.
 
 ## Usage - dynamic linking
 
@@ -43,6 +43,7 @@ still exist when the executable is run.
 
 The makefile here also shows how to create a `.a` static library using the BridgeStan
 source, and then compiling an executable which is independent of the location of the model.
+This can use the same source file as dynamic linking, it is just the build which differs.
 
 ```shell
 make example_static

--- a/c-example/example.c
+++ b/c-example/example.c
@@ -1,12 +1,12 @@
 #include "bridgestan.h"
 #include <stdio.h>
 
-int main(){
-    model_rng* model = construct("", 123, 0);
-    if (!model){
-        return 1;
-    }
-    printf("This model's name is %s.\n", name(model));
-    printf("It has %d parameters.\n", param_num(model, 0, 0));
-    return destruct(model);
+int main() {
+  model_rng* model = construct("", 123, 0);
+  if (!model){
+    return 1;
+  }
+  printf("This model's name is %s.\n", name(model));
+  printf("It has %d parameters.\n", param_num(model, 0, 0));
+  return destruct(model);
 }

--- a/c-example/example.c
+++ b/c-example/example.c
@@ -1,0 +1,12 @@
+#include "bridgestan.h"
+#include <stdio.h>
+
+int main(){
+    model_rng* model = construct("", 123, 0);
+    if (!model){
+        return 1;
+    }
+    printf("This model's name is %s.\n", name(model));
+    printf("It has %d parameters.\n", param_num(model, 0, 0));
+    return destruct(model);
+}

--- a/python/docs/languages/c-api.rst
+++ b/python/docs/languages/c-api.rst
@@ -7,7 +7,9 @@ Core API
 --------
 
 The following are the C functions exposed by the BridgeStan library in ``bridgestan.h``.
-These are wrapped in the various high-level interfaces.
+These are wrapped in the various high-level interfaces. An example calling
+these functions from pure-C can be found in the ``c-example/`` subdirectory
+of the repository.
 
 These functions are actually implemented in C++, see :doc:`../how-it-works` for more details.
 


### PR DESCRIPTION
Discussed in #21, the refactor into headers lets you call bridged models from pure C. This creates an `c-example/` folder with a minimal example of how to do this and how to compile it.