### PR TITLE
Use a Make rule to build all test models

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   CMDSTAN_VERSION: "2.30.1"
-  CACHE_VERSION: 3
+  CACHE_VERSION: 4
 
 jobs:
   build_test_models:
@@ -75,18 +75,16 @@ jobs:
         if: matrix.os != 'windows-latest' && steps.test-models.outputs.cache-hit != 'true'
         run: |
           export CMDSTAN=$(python -c "import cmdstanpy; print(cmdstanpy.cmdstan_path())")/
-          export BRIDGESTAN=$(pwd)
-          bash test_models/build_all.sh
+          make STAN_THREADS=true O=0 test_models -j2
         shell: bash
 
       - name: Build test models (Windows)
         if: matrix.os == 'windows-latest' && steps.test-models.outputs.cache-hit != 'true'
         run: |
-          $env:BRIDGESTAN = $(pwd)
-          $env:CMDSTAN = $(python -c "import cmdstanpy; print(cmdstanpy.cmdstan_path())")
-          ./test_models/build_all.ps1
+          $raw_cmdstan = $(python -c "import cmdstanpy; print(cmdstanpy.cmdstan_path())")
+          $env:CMDSTAN = "$($raw_cmdstan.replace('\', '/'))/"
+          mingw32-make.exe STAN_THREADS=true O=0 test_models -j2
         shell: pwsh
-
 
   test_python_client:
     needs: [build_test_models]

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,12 @@ clean:
 	$(RM) test_models/**/*.so
 	$(RM) test_models/**/*.hpp
 
+# build all test models at once
+TEST_MODEL_LIBS = test_models/throw_tp/throw_tp_model.so test_models/throw_gq/throw_gq_model.so test_models/throw_lp/throw_lp_model.so test_models/throw_data/throw_data_model.so test_models/jacobian/jacobian_model.so test_models/matrix/matrix_model.so test_models/simplex/simplex_model.so test_models/full/full_model.so test_models/stdnormal/stdnormal_model.so test_models/bernoulli/bernoulli_model.so test_models/gaussian/gaussian_model.so test_models/fr_gaussian/fr_gaussian_model.so test_models/simple/simple_model.so test_models/multi/multi_model.so
+
+.PHONY: test_models
+test_models: $(TEST_MODEL_LIBS)
+
 # print compilation command line config
 .PHONY: compile_info
 compile_info:

--- a/test_models/build_all.ps1
+++ b/test_models/build_all.ps1
@@ -1,8 +1,0 @@
-cd $env:BRIDGESTAN
-
-$models = "throw_tp",  "throw_gq",  "throw_lp",  "throw_data",  "jacobian",  "matrix",  "simplex",  "full",  "stdnormal",  "bernoulli",  "multi",  "gaussian",  "fr_gaussian",  "simple"
-
-$cmdstanfixed = $env:CMDSTAN.replace('\', '/')
-foreach ($model in $models) {
-    mingw32-make.exe CMDSTAN="$($cmdstanfixed)/" STAN_THREADS="True" -j4 O=0 "test_models/$($model)/$($model)_model.so"
-}

--- a/test_models/build_all.sh
+++ b/test_models/build_all.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-cd "$BRIDGESTAN"
-models=( throw_tp throw_gq throw_lp throw_data jacobian matrix simplex full stdnormal bernoulli gaussian fr_gaussian simple multi )
-for model in "${models[@]}"
-do
-    CMDSTAN="$CMDSTAN" make STAN_THREADS=True -j2 O=0 test_models/"$model"/"$model"_model.so
-done


### PR DESCRIPTION
This removes `test_models/build_all.sh` and `test_models/build_all.ps1` in favor of simply using a make rule called `test_models` to build all test models. This makes it uniform on all platforms and it allows speedups if you run, e.g. `make test_models -j8`