### PR TITLE
Fix prior in simplex model

### DIFF
--- a/test_models/simplex/simplex.stan
+++ b/test_models/simplex/simplex.stan
@@ -2,5 +2,5 @@ parameters {
   simplex[5] theta;
 }
 model {
-  theta ~ dirichlet(rep_vector(5, 2));
+  theta ~ dirichlet(rep_vector(2, 5));
 }


### PR DESCRIPTION
The Dirichlet prior used in test_models/simplex/simplex.stan was misspecified, fixed to match dimensions of simplex parameter theta.