### PR TITLE
Add `model_info` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ notes.org
 __pycache__/
 .ipynb_checkpoints/
 .pytest_cache/
+.mypy_cache/
 *.egg-info/
 *.pyc
 _build/

--- a/R/R/bridgestan.R
+++ b/R/R/bridgestan.R
@@ -45,6 +45,15 @@ StanModel <- R6::R6Class("StanModel",
       )$name_out
     },
     #' @description
+    #' Get compile information about this Stan model.
+    #' @return A character vector of the Stan version and important flags.
+    model_info = function() {
+      .C("model_info_R", as.raw(private$model),
+        info_out = as.character(""),
+        PACKAGE = private$lib_name
+      )$info_out
+    },
+    #' @description
     #' Return the indexed names of the (constrained) parameters.
     #' For containers, indexes are separated by periods (.).
     #'

--- a/R/man/StanModel.Rd
+++ b/R/man/StanModel.Rd
@@ -19,6 +19,7 @@ as well as constraining and unconstraining transforms.
 \itemize{
 \item \href{#method-StanModel-new}{\code{StanModel$new()}}
 \item \href{#method-StanModel-name}{\code{StanModel$name()}}
+\item \href{#method-StanModel-model_info}{\code{StanModel$model_info()}}
 \item \href{#method-StanModel-param_names}{\code{StanModel$param_names()}}
 \item \href{#method-StanModel-param_unc_names}{\code{StanModel$param_unc_names()}}
 \item \href{#method-StanModel-param_num}{\code{StanModel$param_num()}}
@@ -68,6 +69,19 @@ Get the name of this StanModel
 
 \subsection{Returns}{
 A character vector of the name.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-StanModel-model_info"></a>}}
+\if{latex}{\out{\hypertarget{method-StanModel-model_info}{}}}
+\subsection{Method \code{model_info()}}{
+Get compile information about this Stan model.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{StanModel$model_info()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+A character vector of the Stan version and important flags.
 }
 }
 \if{html}{\out{<hr>}}

--- a/R/tests/testthat/test-bridgestan.R
+++ b/R/tests/testthat/test-bridgestan.R
@@ -6,6 +6,10 @@ test_that("simple_model name is correct", {
     expect_identical(simple$name(), "simple_model")
 })
 
+test_that("simple_model info exists", {
+    expect_true(grepl("STAN_OPENCL", simple$model_info(), fixed = TRUE))
+})
+
 test_that("simple_model param_names are correct", {
     expect_equal(simple$param_names(), c("y.1", "y.2", "y.3", "y.4", "y.5"))
 })

--- a/julia/docs/src/julia.md
+++ b/julia/docs/src/julia.md
@@ -20,6 +20,7 @@ param_constrain
 param_unconstrain
 param_unconstrain_json
 name
+model_info
 param_num
 param_unc_num
 param_names

--- a/julia/src/BridgeStan.jl
+++ b/julia/src/BridgeStan.jl
@@ -2,6 +2,7 @@ module BridgeStan
 
 export StanModel,
     name,
+    model_info,
     param_num,
     param_unc_num,
     param_names,

--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -79,6 +79,24 @@ function name(sm::StanModel)
 end
 
 """
+    model_info(sm)
+
+Return information about the model `sm`.
+
+This includes the Stan version and important
+compiler flags.
+"""
+function model_info(sm::StanModel)
+    cstr = ccall(
+        Libc.Libdl.dlsym(sm.lib, "model_info"),
+        Cstring,
+        (Ptr{StanModelStruct},),
+        sm.stanmodel,
+    )
+    unsafe_string(cstr)
+end
+
+"""
     param_num(sm; include_tp=false, include_gq=false)
 
 Return the number of (constrained) parameters in the model.

--- a/julia/test/model_tests.jl
+++ b/julia/test/model_tests.jl
@@ -28,6 +28,11 @@ end
     @test BridgeStan.name(b) == "stdnormal_model"
 end
 
+@testset "model info" begin
+    b = load_test_model("stdnormal", false)
+    @test occursin("STAN_THREADS=true", BridgeStan.model_info(b))
+end
+
 @testset "param_num" begin
     b = load_test_model("full", false)
     @test BridgeStan.param_num(b) == 1

--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -77,6 +77,10 @@ class StanModel:
         self._name.restype = ctypes.c_char_p
         self._name.argtypes = [ctypes.c_void_p]
 
+        self._model_info = self.stanlib.model_info
+        self._model_info.restype = ctypes.c_char_p
+        self._model_info.argtypes = [ctypes.c_void_p]
+
         self._param_num = self.stanlib.param_num
         self._param_num.restype = ctypes.c_int
         self._param_num.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
@@ -202,6 +206,16 @@ class StanModel:
         :return: The name of Stan model.
         """
         return self._name(self.model_rng).decode("utf-8")
+
+    def model_info(self) -> str:
+        """
+        Return compilation information about the model. For example,
+        this includes the current Stan version and important
+        compiler settings.
+
+        :return: Information about the compiled Stan model.
+        """
+        return self._model_info(self.model_rng).decode("utf-8")
 
     def param_num(self, *, include_tp: bool = False, include_gq: bool = False) -> int:
         """

--- a/python/docs/languages/julia.md
+++ b/python/docs/languages/julia.md
@@ -59,7 +59,7 @@ Return the log density of the specified unconstrained parameters.
 This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L333-L340' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L351-L358' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient' href='#BridgeStan.log_density_gradient'>#</a>
 **`BridgeStan.log_density_gradient`** &mdash; *Function*.
@@ -77,7 +77,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L405-L417' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L423-L435' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian' href='#BridgeStan.log_density_hessian'>#</a>
 **`BridgeStan.log_density_hessian`** &mdash; *Function*.
@@ -95,7 +95,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient and Hessian output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L491-L502' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L509-L520' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain' href='#BridgeStan.param_constrain'>#</a>
 **`BridgeStan.param_constrain`** &mdash; *Function*.
@@ -113,7 +113,7 @@ This allocates new memory for the output each call. See `param_constrain!` for a
 This is the inverse of `param_unconstrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L204-L216' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L222-L234' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain' href='#BridgeStan.param_unconstrain'>#</a>
 **`BridgeStan.param_unconstrain`** &mdash; *Function*.
@@ -133,7 +133,7 @@ This allocates new memory for the output each call. See `param_unconstrain!` for
 This is the inverse of `param_constrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L264-L277' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L282-L295' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json' href='#BridgeStan.param_unconstrain_json'>#</a>
 **`BridgeStan.param_unconstrain_json`** &mdash; *Function*.
@@ -151,7 +151,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 This allocates new memory for the output each call. See `param_unconstrain_json!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L317-L327' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L335-L345' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.name' href='#BridgeStan.name'>#</a>
 **`BridgeStan.name`** &mdash; *Function*.
@@ -167,6 +167,22 @@ Return the name of the model `sm`
 
 <a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L66-L70' class='documenter-source'>source</a><br>
 
+<a id='BridgeStan.model_info' href='#BridgeStan.model_info'>#</a>
+**`BridgeStan.model_info`** &mdash; *Function*.
+
+
+
+```julia
+model_info(sm)
+```
+
+Return information about the model `sm`.
+
+This includes the Stan version and important compiler flags.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L81-L88' class='documenter-source'>source</a><br>
+
 <a id='BridgeStan.param_num' href='#BridgeStan.param_num'>#</a>
 **`BridgeStan.param_num`** &mdash; *Function*.
 
@@ -181,7 +197,7 @@ Return the number of (constrained) parameters in the model.
 This is the total of all the sizes of items declared in the `parameters` block of the model. If `include_tp` or `include_gq` are true, items declared in the `transformed parameters` and `generate quantities` blocks are included, respectively.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L81-L90' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L99-L108' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_num' href='#BridgeStan.param_unc_num'>#</a>
 **`BridgeStan.param_unc_num`** &mdash; *Function*.
@@ -197,7 +213,7 @@ Return the number of unconstrained parameters in the model.
 This function is mainly different from `param_num` when variables are declared with constraints. For example, `simplex[5]` has a constrained size of 5, but an unconstrained size of 4.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L103-L111' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L121-L129' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_names' href='#BridgeStan.param_names'>#</a>
 **`BridgeStan.param_names`** &mdash; *Function*.
@@ -215,7 +231,7 @@ For containers, indexes are separated by periods (.).
 For example, the scalar `a` has indexed name `"a"`, the vector entry `a[1]` has indexed name `"a.1"` and the matrix entry `a[2, 3]` has indexed names `"a.2.3"`. Parameter order of the output is column major and more generally last-index major for containers.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L121-L132' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L139-L150' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_names' href='#BridgeStan.param_unc_names'>#</a>
 **`BridgeStan.param_unc_names`** &mdash; *Function*.
@@ -231,7 +247,7 @@ Return the indexed names of the unconstrained parameters.
 For example, a scalar unconstrained parameter `b` has indexed name `b` and a vector entry `b[3]` has indexed name `b.3`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L145-L152' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L163-L170' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient!' href='#BridgeStan.log_density_gradient!'>#</a>
 **`BridgeStan.log_density_gradient!`** &mdash; *Function*.
@@ -249,7 +265,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out`, and a reference is returned. See `log_density_gradient` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L360-L370' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L378-L388' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian!' href='#BridgeStan.log_density_hessian!'>#</a>
 **`BridgeStan.log_density_hessian!`** &mdash; *Function*.
@@ -267,7 +283,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out_grad` and the Hessian is stored in `out_hess` and references are returned. See `log_density_hessian` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L428-L439' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L446-L457' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain!' href='#BridgeStan.param_constrain!'>#</a>
 **`BridgeStan.param_constrain!`** &mdash; *Function*.
@@ -285,7 +301,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_unconstrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L163-L174' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L181-L192' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain!' href='#BridgeStan.param_unconstrain!'>#</a>
 **`BridgeStan.param_unconstrain!`** &mdash; *Function*.
@@ -305,7 +321,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_constrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L227-L239' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L245-L257' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json!' href='#BridgeStan.param_unconstrain_json!'>#</a>
 **`BridgeStan.param_unconstrain_json!`** &mdash; *Function*.
@@ -323,7 +339,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 The result is stored in the vector `out`, and a reference is returned. See `param_unconstrain_json` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L283-L292' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L301-L310' class='documenter-source'>source</a><br>
 
 
 <a id='Compilation-utilities'></a>

--- a/python/docs/languages/r.md
+++ b/python/docs/languages/r.md
@@ -64,6 +64,21 @@ _Returns_
   A character vector of the name.
 
 
+**Method** `model_info()`:
+
+Get compile information about this Stan model.
+
+_Usage_
+
+```R
+StanModel$model_info()
+```
+
+
+_Returns_
+
+  A character vector of the Stan version and important flags.
+
 **Method** `param_names()`:
 
 Return the indexed names of the (constrained) parameters. For

--- a/python/test/test_stanmodel.py
+++ b/python/test/test_stanmodel.py
@@ -45,6 +45,12 @@ def test_name():
     np.testing.assert_equal("stdnormal_model", b.name())
 
 
+def test_model_info():
+    std_so = str(STAN_FOLDER / "stdnormal" / "stdnormal_model.so")
+    b = bs.StanModel(std_so)
+    assert "STAN_OPENCL" in b.model_info()
+    
+
 def test_param_num():
     full_so = str(STAN_FOLDER / "full" / "full_model.so")
     b = bs.StanModel(full_so)

--- a/src/bridgestan.cpp
+++ b/src/bridgestan.cpp
@@ -30,6 +30,8 @@ int destruct(model_rng* mr) {
 
 const char* name(model_rng* mr) { return mr->name(); }
 
+const char* model_info(model_rng* mr) { return mr->model_info(); }
+
 const char* param_names(model_rng* mr, bool include_tp, bool include_gq) {
   return mr->param_names(include_tp, include_gq);
 }

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -44,6 +44,18 @@ int destruct(model_rng* mr);
 const char* name(model_rng* mr);
 
 /**
+ * Return information about the compiled model as a C-style string.
+ *
+ * The returned string should not be modified; it is freed when the
+ * model and RNG wrapper is destroyed.
+ *
+ * @param[in] mr pointer to model and RNG structure
+ * @return Information about the model including Stan version, Stan defines, and
+ * compiler flags.
+ */
+const char* model_info(model_rng* mr);
+
+/**
  * Return a comma-separated sequence of indexed parameter names,
  * including the transformed parameters and/or generated quantities
  * as specified.

--- a/src/bridgestanR.cpp
+++ b/src/bridgestanR.cpp
@@ -9,6 +9,9 @@ void destruct_R(model_rng** model, int* return_code) {
 void name_R(model_rng** model, char const** name_out) {
   *name_out = name(*model);
 }
+void model_info_R(model_rng** model, char const** info_out){
+  *info_out = model_info(*model);
+}
 void param_names_R(model_rng** model, int* include_tp, int* include_gq,
                    char const** names_out) {
   *names_out = param_names(*model, *include_tp, *include_gq);

--- a/src/bridgestanR.h
+++ b/src/bridgestanR.h
@@ -17,6 +17,8 @@ void destruct_R(model_rng** model, int* return_code);
 
 void name_R(model_rng** model, char const** name_out);
 
+void model_info_R(model_rng** model, char const** info_out);
+
 void param_names_R(model_rng** model, int* include_tp, int* include_gq,
                    char const** name_out);
 

--- a/src/model_rng.hpp
+++ b/src/model_rng.hpp
@@ -39,6 +39,14 @@ class model_rng {
   const char* name();
 
   /**
+   *  Return information about the compiled model. This class manages the
+   * memory, so the returned string should not be freed.
+   *
+   * @return name of model
+   */
+  const char* model_info();
+
+  /**
    * Return the parameter names as a comma-separated list.  Indexes
    * are separted with periods. This class manages the memory, so
    * the returned string should not be freed.
@@ -178,6 +186,9 @@ class model_rng {
 
   /** name of the Stan model */
   char* name_ = nullptr;
+
+  /** Model compile info */
+  char* model_info_ = nullptr;
 
   /** CSV list of parameter names */
   char* param_names_ = nullptr;


### PR DESCRIPTION
This is a proposal for #40. It includes the version, stanc flags, and Stan defines all in one monolithic string. It is based on the `info` subcommand of CmdStan models, with some extra information

This is the most useful version for debugging (e.g., if we want to ask the user to give us some information), but probably the least useful format if we want it to be machine readable, which would be better served with separate functions for all of this.

Example output:

```
Stan version: 2.30.0
Stan C++ Defines:
        STAN_THREADS=true
        STAN_MPI=false
        STAN_OPENCL=false
        STAN_NO_RANGE_CHECKS=false
        STAN_CPP_OPTIMS=false
Stan Compiler Details:
        stanc_version = stanc3 v2.30.1
        stancflags =
```