### PR TITLE
Add warning in R and Julia for re-loading DSOs

### DIFF
--- a/R/R/bridgestan.R
+++ b/R/R/bridgestan.R
@@ -21,10 +21,17 @@ StanModel <- R6::R6Class("StanModel",
         file.copy(from=lib_old, to=lib)
       }
 
-      private$lib <- lib
+      private$lib <- tools::file_path_as_absolute(lib)
       private$lib_name <- tools::file_path_sans_ext(basename(lib))
+      if (is.loaded("construct_R", PACKAGE = private$lib_name)) {
+        warning(
+          paste0("Loading a shared object '", lib, "' which is already loaded.\n",
+                  "If the file has changed since the last time it was loaded, this load may not update the library!"
+          )
+        )
+      }
 
-      dyn.load(lib, PACKAGE = private$lib_name)
+      dyn.load(private$lib, PACKAGE = private$lib_name)
       .C("construct_R",
         as.character(data), as.integer(rng_seed), as.integer(chain_id),
         ptr_out = raw(8),

--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -30,6 +30,11 @@ mutable struct StanModel
             throw(SystemError("Dynamic library file not found"))
         end
 
+        if in(abspath(lib), Libc.Libdl.dllist())
+            @warn "Loading a shared object '" * lib * "' which is already loaded.\n" *
+                  "If the file has changed since the last time it was loaded, this load may not update the library!"
+        end
+
         if data != "" && !isfile(data)
             throw(SystemError("Data file not found"))
         end


### PR DESCRIPTION
See discussions in #36 

I can't figure out if Python exposes a comparable way of testing if a DLL is already loaded or not, so for now this is only in the other two interfaces. 