### PR TITLE
Compilation: Error on use rather than warning on load

### DIFF
--- a/julia/src/BridgeStan.jl
+++ b/julia/src/BridgeStan.jl
@@ -34,15 +34,5 @@ This is equivalent to calling `compile_model` and then the original constructor 
 """
 StanModel(; stan_file::String, data::String = "", seed = 204, chain_id = 0) =
     StanModel(compile_model(stan_file), data, seed, chain_id)
-
-function __init__()
-    if get_bridgestan() == ""
-        @warn "BridgeStan path was not set, compilation will not work until you call `set_bridgestan_path!()`"
-    end
-    if get_cmdstan() == ""
-        @warn "CmdStan path was not set, compilation will not work until you call `set_cmdstan_path!()`"
-    end
-end
-
-
+    
 end

--- a/julia/src/compile.jl
+++ b/julia/src/compile.jl
@@ -4,7 +4,11 @@ function get_make()
 end
 
 function get_bridgestan()
-    get(ENV, "BRIDGESTAN", "")
+    path = get(ENV, "BRIDGESTAN", "")
+    if path == ""
+        error("BridgeStan path was not set, compilation will not work until you call `set_bridgestan_path!()`")
+    end
+    return path
 end
 
 function get_cmdstan()
@@ -18,6 +22,9 @@ function get_cmdstan()
             )[1]
         catch
         end
+    end
+    if cmdstan == ""
+         error("CmdStan path was not set, compilation will not work until you call `set_cmdstan_path!()`")
     end
     return cmdstan
 end

--- a/python/bridgestan/compile.py
+++ b/python/bridgestan/compile.py
@@ -1,7 +1,6 @@
 import os
 import platform
 import subprocess
-import warnings
 from pathlib import Path
 from typing import List
 
@@ -45,24 +44,6 @@ if not CMDSTAN_PATH:
             )
         except:
             pass
-
-if not CMDSTAN_PATH:
-    warnings.warn(
-        RuntimeWarning(
-            "Unable to locate CmdStan, you will need to call "
-            "'set_cmdstan_path()' before using compilation features"
-        )
-    )
-
-try:
-    verify_bridgestan_path(BRIDGESTAN_PATH)
-except ValueError:
-    warnings.warn(
-        RuntimeWarning(
-            "Unable to locate BridgeStan, you will need to call "
-            "'set_bridgestan_path()' before using compilation features"
-        ),
-    )
 
 
 def set_cmdstan_path(path: str) -> None:
@@ -116,6 +97,12 @@ def compile_model(stan_file: str, args: List[str] = []) -> Path:
     :raises RuntimeError: If compilation fails.
     """
     verify_bridgestan_path(BRIDGESTAN_PATH)
+
+    if not CMDSTAN_PATH:
+        raise RuntimeError(
+            "Unable to locate CmdStan, you will need to call "
+            "'set_cmdstan_path()' before using compilation features"
+        )
 
     file_path = Path(stan_file).resolve()
     validate_readable(str(file_path))

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -39,6 +39,9 @@ def test_compile_syntax_error():
 def test_compile_bad_cmdstan():
     stanfile = STAN_FOLDER / "multi" / "multi.stan"
     old_path = bs.compile.CMDSTAN_PATH
+    bs.compile.set_cmdstan_path("")
+    with pytest.raises(RuntimeError, match=r"set_cmdstan_path"):
+        bs.compile_model(stanfile)
     bs.compile.set_cmdstan_path("dummy")
     with pytest.raises(RuntimeError, match=r"Make sure CmdStan is installed"):
         bs.compile_model(stanfile)


### PR DESCRIPTION
Closes #46. 

Based on the feedback in that issue, it seems better to throw an error if someone tries to use the compilation features without having the paths set, rather than a noisy warning every load. This also goes along with e.g. cmdstanpy/r