### PR TITLE
Update GHA workflows to remove deprecated features

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out github
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -44,7 +44,7 @@ jobs:
 
       - name: CmdStan installation cacheing
         id: cmdstan-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cmdstan
           key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -161,10 +161,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@v2.3.1
 
       - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@v2.3.1
         with:
           packages: |
             any::R6
@@ -218,10 +218,10 @@ jobs:
           key: ${{ hashFiles('**/*.stan', 'src/*') }}-windows-latest-cmdstan-${{ env.CMDSTAN_VERSION }}-v${{ env.CACHE_VERSION }}
 
       - name: Install R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@v2.3.1
 
       - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@v2.3.1
         with:
           packages: |
             any::R6

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,10 +21,10 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out github
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: CmdStan installation cacheing
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cmdstan-cache
         with:
           path: ~/.cmdstan
@@ -56,7 +56,7 @@ jobs:
 
       # we use the cache here to build the Stan models once for multiple interfaces
       - name: Set up test model cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: test-models
         with:
           path: ./test_models/
@@ -87,14 +87,14 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out github
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Restore CmdStan
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cmdstan
           key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
@@ -127,18 +127,18 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out github
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
 
       - name: Restore CmdStan
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cmdstan
           key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
 
       - name: Restore built models
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: test-models
         with:
           path: ./test_models/
@@ -158,7 +158,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out github
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2
@@ -172,13 +172,13 @@ jobs:
             any::devtools
 
       - name: Restore CmdStan
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cmdstan
           key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
 
       - name: Restore built models
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: test-models
         with:
           path: ./test_models/
@@ -197,10 +197,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out github
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Restore CmdStan
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cmdstan
           key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
@@ -211,7 +211,7 @@ jobs:
           Add-Content $env:GITHUB_PATH "$(pwd)/stan/lib/stan_math/lib/tbb"
 
       - name: Restore built models
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: test-models
         with:
           path: ./test_models/

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Check out github
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -100,7 +100,7 @@ jobs:
           key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
 
       - name: Restore built models
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: test-models
         with:
           path: ./test_models/


### PR DESCRIPTION
Recent workflow runs have had a lot of deprecation warnings, see: https://github.com/roualdes/bridgestan/actions/runs/3322699971

This updates the versions we are using to resolve them and enables GitHub's "dependabot" to check them monthly