### PR TITLE
Support for Stan 2.31

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CMDSTAN_VERSION: "2.30.1"
+  CMDSTAN_VERSION: "2.31.0-rc1"
 
 jobs:
   build-docs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CMDSTAN_VERSION: "2.31.0-rc1"
+  CMDSTAN_VERSION: "2.31.0"
 
 jobs:
   build-docs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CMDSTAN_VERSION: "2.30.1"
+  CMDSTAN_VERSION: "2.31.0"
   CACHE_VERSION: 0
 
 jobs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CMDSTAN_VERSION: "2.31.0"
+  CMDSTAN_VERSION: "2.31.0-rc1"
   CACHE_VERSION: 0
 
 jobs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CMDSTAN_VERSION: "2.31.0-rc1"
+  CMDSTAN_VERSION: "2.31.0"
   CACHE_VERSION: 0
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 ## include paths
 GITHUB ?= $(HOME)/github/
 CMDSTAN ?= $(GITHUB)stan-dev/cmdstan/
-CMDSTANSRC ?= $(CMDSTAN)src/
 STANC ?= $(CMDSTAN)bin/stanc$(EXE)
 STAN ?= $(CMDSTAN)stan/
 MATH ?= $(STAN)lib/stan_math/
-RAPIDJSON ?= $(CMDSTAN)lib/rapidjson_1.1.0/
+RAPIDJSON ?= $(STAN)lib/rapidjson_1.1.0/
 
 ## required C++ includes
 INC_FIRST ?= -I $(STAN)src -I $(RAPIDJSON)
@@ -35,19 +34,20 @@ else
 endif
 STAN_FLAGS=$(STAN_FLAG_THREADS)$(STAN_FLAG_OPENCL)
 
-BRIDGE ?= src/bridgestan.cpp
-BRIDGE_O = $(patsubst %.cpp,%$(STAN_FLAGS).o,$(BRIDGE))
+SRC ?= src/
+BRIDGE_DEPS = $(SRC)bridgestan.cpp $(SRC)bridgestan.h $(SRC)model_rng.cpp $(SRC)model_rng.hpp $(SRC)bridgestanR.cpp $(SRC)bridgestanR.h
+BRIDGE_O = $(patsubst %.cpp,%$(STAN_FLAGS).o,$(SRC)bridgestan.cpp)
 
 $(STANC):
 	@echo 'stanc could not be found. Make sure CmdStan is installed and built, and that the path specificied is correct:'
 	@echo '$(CMDSTAN)'
 	exit 1
 
-$(BRIDGE_O) : $(BRIDGE)
+$(BRIDGE_O) : $(BRIDGE_DEPS)
 	@echo ''
 	@echo '--- Compiling Stan bridge C++ code ---'
 	@mkdir -p $(dir $@)
-	$(COMPILE.cpp) -fPIC $(CXXFLAGS_THREADS) -I $(CMDSTANSRC) $(OUTPUT_OPTION) $(LDLIBS) $<
+	$(COMPILE.cpp) -fPIC $(CXXFLAGS_THREADS) $(OUTPUT_OPTION) $(LDLIBS) $<
 
 ## generate .hpp file from .stan file using stanc
 %.hpp : %.stan $(STANC)
@@ -76,7 +76,7 @@ docs:
 
 .PHONY: clean
 clean:
-	$(RM) src/*.o
+	$(RM) $(SRC)/*.o
 	$(RM) test_models/**/*.so
 	$(RM) test_models/**/*.hpp
 

--- a/c-example/Makefile
+++ b/c-example/Makefile
@@ -1,5 +1,5 @@
 # Tell the top-level makefile which relative path to use
-BRIDGE=../src/bridgestan.cpp
+SRC=../src/
 include ../Makefile
 
 MODEL?=full

--- a/src/model_rng.cpp
+++ b/src/model_rng.cpp
@@ -271,7 +271,7 @@ void model_rng::log_density_gradient(bool propto, bool jacobian,
   auto logp = make_model_lambda(propto, jacobian);
   int N = param_unc_num_;
   Eigen::VectorXd params_unc = Eigen::VectorXd::Map(theta_unc, N);
-  stan::math::gradient(logp, params_unc, *val, grad, grad + param_unc_num_);
+  stan::math::gradient(logp, params_unc, *val, grad, grad + N);
 }
 
 void model_rng::log_density_hessian(bool propto, bool jacobian,

--- a/src/model_rng.cpp
+++ b/src/model_rng.cpp
@@ -1,5 +1,5 @@
 #include "model_rng.hpp"
-#include <cmdstan/io/json/json_data.hpp>
+#include <stan/io/json/json_data.hpp>
 #include <stan/io/array_var_context.hpp>
 #include <stan/io/empty_var_context.hpp>
 #include <stan/io/var_context.hpp>
@@ -61,7 +61,7 @@ model_rng::model_rng(const char* data_file, unsigned int seed,
     std::ifstream in(data);
     if (!in.good())
       throw std::runtime_error("Cannot read input file: " + data);
-    auto data_context = cmdstan::json::json_data(in);
+    auto data_context = stan::json::json_data(in);
     in.close();
     model_ = &new_model(data_context, seed, &std::cerr);
   }
@@ -211,7 +211,7 @@ void model_rng::param_unconstrain(const double* theta, double* theta_unc) {
 
 void model_rng::param_unconstrain_json(const char* json, double* theta_unc) {
   std::stringstream in(json);
-  cmdstan::json::json_data inits_context(in);
+  stan::json::json_data inits_context(in);
   Eigen::VectorXd params_unc;
   model_->transform_inits(inits_context, params_unc, &std::cerr);
   Eigen::VectorXd::Map(theta_unc, params_unc.size()) = params_unc;
@@ -271,9 +271,7 @@ void model_rng::log_density_gradient(bool propto, bool jacobian,
   auto logp = make_model_lambda(propto, jacobian);
   int N = param_unc_num_;
   Eigen::VectorXd params_unc = Eigen::VectorXd::Map(theta_unc, N);
-  Eigen::VectorXd grad_vec(N);
-  stan::math::gradient(logp, params_unc, *val, grad_vec);
-  Eigen::VectorXd::Map(grad, N) = grad_vec;
+  stan::math::gradient(logp, params_unc, *val, grad, grad + param_unc_num_);
 }
 
 void model_rng::log_density_hessian(bool propto, bool jacobian,


### PR DESCRIPTION
Now that the release candidates are out (https://github.com/stan-dev/cmdstan/issues/1126) we can start testing against them and making the required changes for the next version.

We shouldn't merge this until 2.31 is officially released (~18th of November).

Changes:
- JSON now lives in stan repository instead of cmdstan. We can now drop cmdstan dependency, if we want, in a separate PR.
- We can avoid an extra copy being made in the gradient calculations