### PR TITLE
Remove CmdStan dependency. 

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,9 +6,6 @@ on:
       - 'main'
   workflow_dispatch: {}
 
-env:
-  CMDSTAN_VERSION: "2.31.0"
-
 jobs:
   build-docs:
     name: Publish documentation to gh-pages
@@ -23,6 +20,8 @@ jobs:
     steps:
       - name: Check out github
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -42,18 +41,12 @@ jobs:
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
 
-      - name: CmdStan installation cacheing
-        id: cmdstan-cache
+      - name: Stan submodule cacheing
         uses: actions/cache@v3
+        id: stan-cache
         with:
-          path: ~/.cmdstan
-          key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
-
-      - name: Install CmdStan
-        if: steps.cmdstan-cache.outputs.cache-hit != 'true'
-        run: |
-          python -m pip install cmdstanpy
-          python -m cmdstanpy.install_cmdstan --version "${{ env.CMDSTAN_VERSION }}" --cores 2
+          path: ./stan/
+          key: ${{ runner.os }}-stan-${{ hashFiles('stan/src/stan/version.hpp') }}-v${{ env.CACHE_VERSION }}
 
       - name: Install package
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,8 +8,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CMDSTAN_VERSION: "2.31.0"
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
 
 jobs:
   build_test_models:
@@ -22,28 +21,19 @@ jobs:
     steps:
       - name: Check out github
         uses: actions/checkout@v3
-
-      - name: CmdStan installation cacheing
-        uses: actions/cache@v3
-        id: cmdstan-cache
         with:
-          path: ~/.cmdstan
-          key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
+          submodules: recursive
 
-      - name: Install CmdStan (Unix)
-        if: matrix.os != 'windows-latest'
-        run: |
-          pipx run --spec cmdstanpy install_cmdstan --version "${{ env.CMDSTAN_VERSION }}" --cores 2 --verbose
-
-      - name: Install CmdStan (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          pipx run --spec cmdstanpy install_cmdstan --version "${{ env.CMDSTAN_VERSION }}" --cores 2 --verbose --compiler
+      - name: Stan build caching
+        uses: actions/cache@v3
+        id: stan-cache
+        with:
+          path: ./stan/
+          key: ${{ runner.os }}-stan-${{ hashFiles('stan/src/stan/version.hpp') }}-v${{ env.CACHE_VERSION }}
 
       - name: Build C example (Unix)
         if: matrix.os != 'windows-latest'
         run: |
-          export CMDSTAN=~/.cmdstan/cmdstan-${{ env.CMDSTAN_VERSION }}/
           cd c-example/
           make example
           make example_static
@@ -60,20 +50,17 @@ jobs:
         id: test-models
         with:
           path: ./test_models/
-          key: ${{ hashFiles('**/*.stan', 'src/*') }}-${{ matrix.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}-v${{ env.CACHE_VERSION }}
+          key: ${{ hashFiles('**/*.stan', 'src/*', 'stan/src/stan/version.hpp') }}-${{ matrix.os }}-v${{ env.CACHE_VERSION }}
 
       - name: Build test models (Unix)
         if: matrix.os != 'windows-latest' && steps.test-models.outputs.cache-hit != 'true'
         run: |
-          export CMDSTAN=~/.cmdstan/cmdstan-${{ env.CMDSTAN_VERSION }}/
           make STAN_THREADS=true O=0 test_models -j2
         shell: bash
 
       - name: Build test models (Windows)
         if: matrix.os == 'windows-latest' && steps.test-models.outputs.cache-hit != 'true'
         run: |
-          $raw_cmdstan = "$($HOME)/.cmdstan/cmdstan-${{ env.CMDSTAN_VERSION }}/"
-          $env:CMDSTAN = $raw_cmdstan.replace('\', '/')
           mingw32-make.exe STAN_THREADS=true O=0 test_models -j2
         shell: pwsh
 
@@ -88,23 +75,27 @@ jobs:
     steps:
       - name: Check out github
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Restore CmdStan
+      - name: Restore Stan
         uses: actions/cache@v3
+        id: stan-cache
         with:
-          path: ~/.cmdstan
-          key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
+          path: ./stan/
+          key: ${{ runner.os }}-stan-${{ hashFiles('stan/src/stan/version.hpp') }}-v${{ env.CACHE_VERSION }}
 
       - name: Restore built models
         uses: actions/cache@v3
         id: test-models
         with:
           path: ./test_models/
-          key: ${{ hashFiles('**/*.stan', 'src/*') }}-${{ matrix.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}-v${{ env.CACHE_VERSION }}
+          key: ${{ hashFiles('**/*.stan', 'src/*', 'stan/src/stan/version.hpp') }}-${{ matrix.os }}-v${{ env.CACHE_VERSION }}
 
       - name: Install package
         run: |
@@ -128,21 +119,25 @@ jobs:
     steps:
       - name: Check out github
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
 
-      - name: Restore CmdStan
+      - name: Restore Stan
         uses: actions/cache@v3
+        id: stan-cache
         with:
-          path: ~/.cmdstan
-          key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
+          path: ./stan/
+          key: ${{ runner.os }}-stan-${{ hashFiles('stan/src/stan/version.hpp') }}-v${{ env.CACHE_VERSION }}
 
       - name: Restore built models
         uses: actions/cache@v3
         id: test-models
         with:
           path: ./test_models/
-          key: ${{ hashFiles('**/*.stan', 'src/*') }}-${{ matrix.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}-v${{ env.CACHE_VERSION }}
+          key: ${{ hashFiles('**/*.stan', 'src/*', 'stan/src/stan/version.hpp') }}-${{ matrix.os }}-v${{ env.CACHE_VERSION }}
 
       - name: Run tests
         run: |
@@ -159,6 +154,8 @@ jobs:
     steps:
       - name: Check out github
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2.3.1
@@ -171,18 +168,18 @@ jobs:
             any::testthat
             any::devtools
 
-      - name: Restore CmdStan
+      - name: Restore Stan
         uses: actions/cache@v3
         with:
-          path: ~/.cmdstan
-          key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
+          path: ./stan/
+          key: ${{ runner.os }}-stan-${{ hashFiles('stan/src/stan/version.hpp') }}-v${{ env.CACHE_VERSION }}
 
       - name: Restore built models
         uses: actions/cache@v3
         id: test-models
         with:
           path: ./test_models/
-          key: ${{ hashFiles('**/*.stan', 'src/*') }}-${{ matrix.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}-v${{ env.CACHE_VERSION }}
+          key: ${{ hashFiles('**/*.stan', 'src/*', 'stan/src/stan/version.hpp') }}-${{ matrix.os }}-v${{ env.CACHE_VERSION }}
 
       - name: Run tests
         run: |
@@ -198,16 +195,18 @@ jobs:
     steps:
       - name: Check out github
         uses: actions/checkout@v3
-
-      - name: Restore CmdStan
-        uses: actions/cache@v3
         with:
-          path: ~/.cmdstan
-          key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
+          submodules: recursive
+
+      - name: Restore Stan
+        uses: actions/cache@v3
+        id: stan-cache
+        with:
+          path: ./stan/
+          key: ${{ runner.os }}-stan-${{ hashFiles('stan/src/stan/version.hpp') }}-v${{ env.CACHE_VERSION }}
 
       - name: Setup TBB
         run: |
-          cd ~/.cmdstan/cmdstan-${{ env.CMDSTAN_VERSION }}
           Add-Content $env:GITHUB_PATH "$(pwd)/stan/lib/stan_math/lib/tbb"
 
       - name: Restore built models
@@ -215,7 +214,7 @@ jobs:
         id: test-models
         with:
           path: ./test_models/
-          key: ${{ hashFiles('**/*.stan', 'src/*') }}-windows-latest-cmdstan-${{ env.CMDSTAN_VERSION }}-v${{ env.CACHE_VERSION }}
+          key: ${{ hashFiles('**/*.stan', 'src/*', 'stan/src/stan/version.hpp') }}-windows-latest-v${{ env.CACHE_VERSION }}
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2.3.1

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ bridgestan.Rcheck/
 build/
 
 .DS_Store
+
+bin/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "stan"]
+	path = stan
+	url = https://github.com/stan-dev/stan
+	branch = master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ If you wish to build the C++ portions of the documentation, you should also have
 
 ## Builds
 
-We use [Gnu make](https://www.gnu.org/software/make/) for builds.  If you have installed [CmdStan](https://mc-stan.org/users/interfaces/cmdstan) as required for the source to work, then you will already have Gnu make and a sufficient C++ compiler.
+We use [Gnu make](https://www.gnu.org/software/make/) for builds.  If you have installed [CmdStan](https://mc-stan.org/users/interfaces/cmdstan), then you will already have Gnu make and a sufficient C++ compiler.
 
 
 ## Language specific practices

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ RAPIDJSON ?= $(STAN)lib/rapidjson_1.1.0/
 INC_FIRST ?= -I $(STAN)src -I $(RAPIDJSON)
 
 ## makefiles needed for math library
+-include $(BS_ROOT)/make/local
 -include $(MATH)make/compiler_flags
 -include $(MATH)make/dependencies
 -include $(MATH)make/libraries

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,15 @@
 ## include paths
-GITHUB ?= $(HOME)/github/
-CMDSTAN ?= $(GITHUB)stan-dev/cmdstan/
-STANC ?= $(CMDSTAN)bin/stanc$(EXE)
-STAN ?= $(CMDSTAN)stan/
+BS_ROOT ?= .
+SRC ?= $(BS_ROOT)/src/
+STAN ?= $(BS_ROOT)/stan/
+STANC ?= $(BS_ROOT)/bin/stanc$(EXE)
 MATH ?= $(STAN)lib/stan_math/
 RAPIDJSON ?= $(STAN)lib/rapidjson_1.1.0/
 
 ## required C++ includes
 INC_FIRST ?= -I $(STAN)src -I $(RAPIDJSON)
 
-## set CXX = g++ and CX_TYPE to gcc to run under linux
-OS ?= $(shell uname -s)
-CXX ?= clang++
-CXX_TYPE ?= clang
-
 ## makefiles needed for math library
--include $(CMDSTAN)/make/local
 -include $(MATH)make/compiler_flags
 -include $(MATH)make/dependencies
 -include $(MATH)make/libraries
@@ -34,14 +28,8 @@ else
 endif
 STAN_FLAGS=$(STAN_FLAG_THREADS)$(STAN_FLAG_OPENCL)
 
-SRC ?= src/
 BRIDGE_DEPS = $(SRC)bridgestan.cpp $(SRC)bridgestan.h $(SRC)model_rng.cpp $(SRC)model_rng.hpp $(SRC)bridgestanR.cpp $(SRC)bridgestanR.h
 BRIDGE_O = $(patsubst %.cpp,%$(STAN_FLAGS).o,$(SRC)bridgestan.cpp)
-
-$(STANC):
-	@echo 'stanc could not be found. Make sure CmdStan is installed and built, and that the path specificied is correct:'
-	@echo '$(CMDSTAN)'
-	exit 1
 
 $(BRIDGE_O) : $(BRIDGE_DEPS)
 	@echo ''
@@ -79,12 +67,22 @@ clean:
 	$(RM) $(SRC)/*.o
 	$(RM) test_models/**/*.so
 	$(RM) test_models/**/*.hpp
+	$(RM) bin/stanc$(EXE)
+
 
 # build all test models at once
 TEST_MODEL_LIBS = test_models/throw_tp/throw_tp_model.so test_models/throw_gq/throw_gq_model.so test_models/throw_lp/throw_lp_model.so test_models/throw_data/throw_data_model.so test_models/jacobian/jacobian_model.so test_models/matrix/matrix_model.so test_models/simplex/simplex_model.so test_models/full/full_model.so test_models/stdnormal/stdnormal_model.so test_models/bernoulli/bernoulli_model.so test_models/gaussian/gaussian_model.so test_models/fr_gaussian/fr_gaussian_model.so test_models/simple/simple_model.so test_models/multi/multi_model.so
 
 .PHONY: test_models
 test_models: $(TEST_MODEL_LIBS)
+
+.PHONY: stan-update stan-update-version
+stan-update:
+	git submodule update --init --recursive
+
+stan-update-remote:
+	git submodule update --remote --init --recursive
+	git submodule update --init --recursive
 
 # print compilation command line config
 .PHONY: compile_info
@@ -94,3 +92,43 @@ compile_info:
 ## print value of makefile variable (e.g., make print-TBB_TARGETS)
 .PHONY: print-%
 print-%  : ; @echo $* = $($*) ;
+
+# handles downloading of stanc
+STANC_DL_RETRY = 5
+STANC_DL_DELAY = 10
+STANC3_TEST_BIN_URL ?=
+STANC3_VERSION ?= v2.31.0
+
+ifeq ($(OS),Windows_NT)
+ OS_TAG := windows
+else ifeq ($(OS),Darwin)
+ OS_TAG := mac
+else ifeq ($(OS),Linux)
+ OS_TAG := linux
+ ifeq ($(shell uname -m),mips64)
+  ARCH_TAG := -mips64el
+ else ifeq ($(shell uname -m),ppc64le)
+  ARCH_TAG := -ppc64el
+ else ifeq ($(shell uname -m),s390x)
+  ARCH_TAG := -s390x
+ else ifeq ($(shell uname -m),aarch64)
+  ARCH_TAG := -arm64
+ else ifeq ($(shell uname -m),armv7l)
+  ifeq ($(shell readelf -A /usr/bin/file | grep Tag_ABI_VFP_args),)
+    ARCH_TAG := -armel
+  else
+    ARCH_TAG := -armhf
+  endif
+ endif
+endif
+
+ifeq ($(OS_TAG),windows)
+$(STANC):
+	@mkdir -p $(dir $@)
+	$(shell echo "curl -L https://github.com/stan-dev/stanc3/releases/download/$(STANC3_VERSION)/$(OS_TAG)-stanc -o $(STANC) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)")
+else
+$(STANC):
+	@mkdir -p $(dir $@)
+	curl -L https://github.com/stan-dev/stanc3/releases/download/$(STANC3_VERSION)/$(OS_TAG)$(ARCH_TAG)-stanc -o $(STANC) --retry $(STANC_DL_RETRY) --retry-delay $(STANC_DL_DELAY)
+	chmod +x $(STANC)
+endif

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Stan is a probabilistic programming language for coding statistical
 models.  For an introduction to what can be coded in Stan, see the
 [*Stan User's Guide*](https://mc-stan.org/docs/stan-users-guide/index.html).
 
+BridgeStan is currently shipping with Stan version 2.31.0
 
 More documentation is available at https://roualdes.github.io/bridgestan/
 
@@ -26,11 +27,10 @@ compiler combinations.
 
 ## Installing BridgeStan
 
-### Step 1: Install C++, make, and CmdStan
+### Step 1: Install a C++14 compiler and make
 
 See the section [Prerequisites](#prerequisites) for instructions on
-installing a C++ toolchain and CmdStan.  Please verify CmdStan is
-working before proceeding.
+installing a C++ toolchain.
 
 ### Step 2: Download BridgeStan
 
@@ -38,11 +38,13 @@ To download BridgeStan into directory `<parent-dir>`, use the following.
 
 ```shell
 $ cd <parent-dir>
-$ git clone https://gitlab.com/roualdes/bridgestan.git
+$ git clone --recurse-submodules https://github.com/roualdes/bridgestan.git
 ```
 
-There is no need to build anything up front.
+If you clone without the `--recurse-submodules` argument, you can download the required
+submodules with `make stan-update`.
 
+There is no need to build anything up front.
 
 ## Using BridgeStan
 
@@ -56,10 +58,8 @@ shared object (`.so` file), use the following.
 
 ```
 $ cd bridgestan
-$ CMDSTAN=/path/to/cmdstan/ make test_models/multi/multi_model.so
+$ make test_models/multi/multi_model.so
 ```
-
-The forward slash (`/`) at the end of `cmdstan/` is necessary.
 
 ### Using BridgeStan with Python or Julia
 
@@ -80,12 +80,7 @@ By default, BridgeStan uses the default compiler flags set from
 CmdStan's `makefile`.  To override the defaults or add new flags, create
 or edit the file
 
-* local make commands: `<cmdstan-dir>/make/local`.
-
-To help get started, CmdStan includes an example
-`<cmdstan-dir>/make/local.example` that can be copied to
-`<cmdstan-dir>/make/local`.
-
+* local make commands: `<bridgestan dir>/make/local`.
 
 For example, setting the contents of `make/local` to the following
 includes compiler flags for optimization level and architecture.
@@ -127,15 +122,6 @@ will most likely lead to segmentation faults or other crashes.
 
 ## Tips
 
-### Windows paths
-
-On Windows, BridgeStan requires *forward slashes* in the path to
-CmdStan, as in the following example.
-
-```shell
-mingw32-make.exe CMDSTAN="C:/path/to/cmdstan/" ./test_models/multi/multi_model.so
-```
-
 ### Sizes and `param_constrain()` and `param_unconstrain()`
 
 For a given vector `q` of unconstrained parameters, the function
@@ -166,48 +152,29 @@ The interfaces may depend on different packages in their respective languages.
 Stan requires a C++ tool chain consisting of
 
 * A C++11 compiler
-* The Gnu `make` utility for \*nix *or* mingw for Windows
+* The Gnu `make` utility for \*nix *or* `mingw32-make` for Windows
 
-Here are complete instructions by platform for installing both.
+Here are complete instructions by platform for installing both, from the CmdStan installation instructions.
 
 * [C++ tool chain installation](https://mc-stan.org/docs/cmdstan-guide/cmdstan-installation.html#cpp-toolchain)
-
-### Prereq: CmdStan
-
-To install CmdStan, follow the instructions in the guide,
-
-* [Getting Started with CmdStan](https://mc-stan.org/docs/cmdstan-guide/cmdstan-installation.html)
 
 
 ### Ensuring tools are built/imported
 
 At this point, everything should be in place to build and execute a
-Stan program.  We will assume
-
-* CmdStan is installed in `<cmdstan-dir>`, and
-* BridgeStan is checked out in `<bridgestan-dir>`.
+Stan program.  We will assume BridgeStan is checked out in `<bridgestan-dir>`.
 
 To verify the compiler chain is installed correctly, the following
 should run without errors.
 
 ```shell
-cd <cmdstan-dir>
-make <bridgestan-dir>/test_models/multi/multi
+cd <bridgestan-dir>
+make test_models/multi/multi
 ```
-
-The second command brings in the latest version of Stan.
 
 This will require internet access the first time you run it in order
 to download the appropriate Stan compiler for your platform into
-`<cmdstan-dir>/bin/stanc[.exe]`
-
-You can verify CmdStan works end-to-end by using the resulting
-executable to fit some data.
-
-```shell
-./<bridgestan-dir>/test_models/multi/multi sample data file=<bridgestan-dir>/test_models/multi/multi.data.json
-```
-
+`<bridgestan-dir>/bin/stanc[.exe]`
 
 ## Acknowledgements
 

--- a/c-example/Makefile
+++ b/c-example/Makefile
@@ -1,5 +1,5 @@
 # Tell the top-level makefile which relative path to use
-SRC=../src/
+BS_ROOT=..
 include ../Makefile
 
 MODEL?=full

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,14 +2,17 @@
 Installation
 ============
 
-Requirement: C++ toolchain and CmdStan
---------------------------------------
-BridgeStan relies on `CmdStan <https://github.com/stan-dev/cmdstan>`__ and
-the following assume you have a working installation for your system.
-Please make sure you are able to compile and run the CmdStan example program **before continuing**.
+Requirement: C++ toolchain
+--------------------------
 
-For more information,
-see the `CmdStan installation instructions <https://mc-stan.org/docs/cmdstan-guide/cmdstan-installation.html>`__.
+Stan requires a C++ tool chain consisting of
+
+* A C++14 compiler. On Windows, MSCV is *not* supported, so something like MinGW GCC is required.
+* The Gnu ``make`` utility for \*nix *or* ``mingw32-make`` for Windows
+
+Here are complete instructions by platform for installing both, from the CmdStan installation instructions.
+
+* `C++ tool chain installation<https://mc-stan.org/docs/cmdstan-guide/cmdstan-installation.html#cpp-toolchain>`__
 
 Download
 --------
@@ -18,11 +21,7 @@ Installing BridgeStan is as simple as ensuring that the above pre-requisites are
 the source repository.
 
 If you have ``git`` installed, you may do this by navigating to the folder you'd like
-BridgeStan to be in and running ``git clone git@github.com:roualdes/bridgestan.git``.
-
-If you do not have ``git`` installed, you can download a `.zip` file containing the repository
-`here <https://github.com/roualdes/bridgestan/archive/refs/heads/main.zip>`__. Unzip this
-file into the folder you would like BridgeStan to be in.
+BridgeStan to be in and running ``$ git clone --recurse-submodules https://github.com/roualdes/bridgestan.git``.
 
 After this, BridgeStan is installed. You can test a basic compilation by opening
 a terminal in your BridgeStan folder and running
@@ -30,13 +29,12 @@ a terminal in your BridgeStan folder and running
 .. code-block:: shell
 
     # MacOS and Linux
-    make CMDSTAN=/path/to/cmdstan/here/ test_models/multi/multi_model.so
+    make test_models/multi/multi_model.so
     # Windows
-    mingw32-make.exe CMDSTAN=C:/path/to/cmdstan/with/forward/slashes/ test_models/multi/multi_model.so
+    mingw32-make.exe test_models/multi/multi_model.so
 
 This will compile the file ``test_models/multi/multi.stan`` into a shared library object for use with BridgeStan.
-
-
+This requires internet access the first time it is run.
 
 Interface: Python
 -----------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -36,6 +36,25 @@ a terminal in your BridgeStan folder and running
 This will compile the file ``test_models/multi/multi.stan`` into a shared library object for use with BridgeStan.
 This requires internet access the first time it is run.
 
+
+Using custom Stan versions
+--------------------------
+
+If you wish to use BridgeStan for an older released version, all you need to do is
+
+1. Set ``STANC3_VERSION`` in ``make/local`` to your desired version, e.g. ``v2.26.0``
+2. Go into the ``stan`` submodule and run ``git checkout release/VERSION``, e.g. ``release/v2.26.0``
+3. Also in the ``stan`` submodule, run `make math-update`
+
+To return to the version of Stan currently used by BridgeStan, you can run ``make stan-update`` from the top level directory
+and remove ``STANC3_VERSION`` from your ``make/local`` file.
+
+
+If you wish to use BridgeStan with a custom fork or branch, the best thing to do is to check out that branch in the ``stan`` submodule,
+or, if the fork is of stan-math, in ``stan/libs/stan_math``. The easiest way to use a custom stanc3 is to place the built executable at
+`bin/stanc[.exe]`.
+
+
 Interface: Python
 -----------------
 

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -59,7 +59,7 @@ Return the log density of the specified unconstrained parameters.
 This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L351-L358' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L356-L363' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient' href='#BridgeStan.log_density_gradient'>#</a>
 **`BridgeStan.log_density_gradient`** &mdash; *Function*.
@@ -77,7 +77,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L423-L435' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L428-L440' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian' href='#BridgeStan.log_density_hessian'>#</a>
 **`BridgeStan.log_density_hessian`** &mdash; *Function*.
@@ -95,7 +95,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient and Hessian output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L509-L520' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L514-L525' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain' href='#BridgeStan.param_constrain'>#</a>
 **`BridgeStan.param_constrain`** &mdash; *Function*.
@@ -113,7 +113,7 @@ This allocates new memory for the output each call. See `param_constrain!` for a
 This is the inverse of `param_unconstrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L222-L234' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L227-L239' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain' href='#BridgeStan.param_unconstrain'>#</a>
 **`BridgeStan.param_unconstrain`** &mdash; *Function*.
@@ -133,7 +133,7 @@ This allocates new memory for the output each call. See `param_unconstrain!` for
 This is the inverse of `param_constrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L282-L295' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L287-L300' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json' href='#BridgeStan.param_unconstrain_json'>#</a>
 **`BridgeStan.param_unconstrain_json`** &mdash; *Function*.
@@ -151,7 +151,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 This allocates new memory for the output each call. See `param_unconstrain_json!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L335-L345' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L340-L350' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.name' href='#BridgeStan.name'>#</a>
 **`BridgeStan.name`** &mdash; *Function*.
@@ -165,7 +165,7 @@ name(sm)
 Return the name of the model `sm`
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L66-L70' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L71-L75' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.model_info' href='#BridgeStan.model_info'>#</a>
 **`BridgeStan.model_info`** &mdash; *Function*.
@@ -181,7 +181,7 @@ Return information about the model `sm`.
 This includes the Stan version and important compiler flags.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L81-L88' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L86-L93' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_num' href='#BridgeStan.param_num'>#</a>
 **`BridgeStan.param_num`** &mdash; *Function*.
@@ -197,7 +197,7 @@ Return the number of (constrained) parameters in the model.
 This is the total of all the sizes of items declared in the `parameters` block of the model. If `include_tp` or `include_gq` are true, items declared in the `transformed parameters` and `generate quantities` blocks are included, respectively.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L99-L108' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L104-L113' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_num' href='#BridgeStan.param_unc_num'>#</a>
 **`BridgeStan.param_unc_num`** &mdash; *Function*.
@@ -213,7 +213,7 @@ Return the number of unconstrained parameters in the model.
 This function is mainly different from `param_num` when variables are declared with constraints. For example, `simplex[5]` has a constrained size of 5, but an unconstrained size of 4.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L121-L129' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L126-L134' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_names' href='#BridgeStan.param_names'>#</a>
 **`BridgeStan.param_names`** &mdash; *Function*.
@@ -231,7 +231,7 @@ For containers, indexes are separated by periods (.).
 For example, the scalar `a` has indexed name `"a"`, the vector entry `a[1]` has indexed name `"a.1"` and the matrix entry `a[2, 3]` has indexed names `"a.2.3"`. Parameter order of the output is column major and more generally last-index major for containers.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L139-L150' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L144-L155' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_names' href='#BridgeStan.param_unc_names'>#</a>
 **`BridgeStan.param_unc_names`** &mdash; *Function*.
@@ -247,7 +247,7 @@ Return the indexed names of the unconstrained parameters.
 For example, a scalar unconstrained parameter `b` has indexed name `b` and a vector entry `b[3]` has indexed name `b.3`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L163-L170' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L168-L175' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient!' href='#BridgeStan.log_density_gradient!'>#</a>
 **`BridgeStan.log_density_gradient!`** &mdash; *Function*.
@@ -265,7 +265,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out`, and a reference is returned. See `log_density_gradient` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L378-L388' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L383-L393' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian!' href='#BridgeStan.log_density_hessian!'>#</a>
 **`BridgeStan.log_density_hessian!`** &mdash; *Function*.
@@ -283,7 +283,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out_grad` and the Hessian is stored in `out_hess` and references are returned. See `log_density_hessian` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L446-L457' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L451-L462' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain!' href='#BridgeStan.param_constrain!'>#</a>
 **`BridgeStan.param_constrain!`** &mdash; *Function*.
@@ -301,7 +301,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_unconstrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L181-L192' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L186-L197' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain!' href='#BridgeStan.param_unconstrain!'>#</a>
 **`BridgeStan.param_unconstrain!`** &mdash; *Function*.
@@ -321,7 +321,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_constrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L245-L257' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L250-L262' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json!' href='#BridgeStan.param_unconstrain_json!'>#</a>
 **`BridgeStan.param_unconstrain_json!`** &mdash; *Function*.
@@ -339,7 +339,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 The result is stored in the vector `out`, and a reference is returned. See `param_unconstrain_json` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L301-L310' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L306-L315' class='documenter-source'>source</a><br>
 
 
 <a id='Compilation-utilities'></a>
@@ -359,10 +359,10 @@ compile_model(stan_file, args=[])
 
 Run BridgeStan’s Makefile on a `.stan` file, creating the `.so` used by StanModel and return a path to the compiled library. Additional arguments to `make` can be passed as a vector, for example `["STAN_THREADS=true"]` enables the model's threading capabilities.
 
-This function assumes that the paths to BridgeStan and CmdStan are both valid. These can be set with `set_bridgestan_path!()` and `set_cmdstan_path!()` if their default values do not match your system configuration.
+This function assumes that the paths to BridgeStan is valid. This can be set with `set_bridgestan_path!()`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L66-L77' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L40-L50' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.set_bridgestan_path!' href='#BridgeStan.set_bridgestan_path!'>#</a>
 **`BridgeStan.set_bridgestan_path!`** &mdash; *Function*.
@@ -378,21 +378,5 @@ Set the path BridgeStan.
 By default this is set to the value of the environment variable `BRIDGESTAN`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L52-L59' class='documenter-source'>source</a><br>
-
-<a id='BridgeStan.set_cmdstan_path!' href='#BridgeStan.set_cmdstan_path!'>#</a>
-**`BridgeStan.set_cmdstan_path!`** &mdash; *Function*.
-
-
-
-```julia
-set_cmdstan_path!(path)
-```
-
-Set the path to CmdStan used by BridgeStan.
-
-By default this is set to the value of the environment variable `CMDSTAN`, or to the newest installation available in `~/.cmdstan/`.
-
-
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L36-L43' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L26-L33' class='documenter-source'>source</a><br>
 

--- a/docs/languages/python.rst
+++ b/docs/languages/python.rst
@@ -17,4 +17,3 @@ Compilation utilities
 
 .. autofunction:: bridgestan.compile_model
 .. autofunction:: bridgestan.set_bridgestan_path
-.. autofunction:: bridgestan.set_cmdstan_path

--- a/julia/docs/src/julia.md
+++ b/julia/docs/src/julia.md
@@ -36,5 +36,4 @@ param_unconstrain_json!
 ```@docs
 compile_model
 set_bridgestan_path!
-set_cmdstan_path!
 ```

--- a/julia/src/BridgeStan.jl
+++ b/julia/src/BridgeStan.jl
@@ -18,7 +18,6 @@ export StanModel,
     log_density,
     log_density_gradient,
     log_density_hessian,
-    set_cmdstan_path!,
     set_bridgestan_path!,
     compile_model
 
@@ -32,7 +31,7 @@ Construct a StanModel instance from a `.stan` file, compiling if necessary.
 
 This is equivalent to calling `compile_model` and then the original constructor of StanModel.
 """
-StanModel(; stan_file::String, data::String = "", seed = 204, chain_id = 0) =
+StanModel(; stan_file::String, data::String="", seed=204, chain_id=0) =
     StanModel(compile_model(stan_file), data, seed, chain_id)
-    
+
 end

--- a/julia/test/compile_tests.jl
+++ b/julia/test/compile_tests.jl
@@ -33,7 +33,6 @@ end
 
 
 @testset "bad paths" begin
-    @test_throws ErrorException BridgeStan.set_cmdstan_path!("dummy")
     @test_throws ErrorException BridgeStan.set_bridgestan_path!("dummy")
     @test_throws ErrorException BridgeStan.set_bridgestan_path!(models)
 end

--- a/julia/test/model_tests.jl
+++ b/julia/test/model_tests.jl
@@ -431,7 +431,7 @@ end
 
 @testset "bernoulli" begin
     # Bernoulli
-    # CMDSTAN=/path/to/cmdstan/ make test_models/bernoulli/bernoulli_model.so
+    # make test_models/bernoulli/bernoulli_model.so
 
     model = load_test_model("bernoulli")
 
@@ -463,7 +463,7 @@ end
 
 @testset "threaded model: multi" begin
     # Multivariate Gaussian
-    # CMDSTAN=/path/to/cmdstan/ make test_models/multi/multi_model.so
+    # make test_models/multi/multi_model.so
 
     function gaussian(x)
         return -0.5 * x' * x
@@ -497,7 +497,7 @@ end
 
 @testset "gaussian" begin
     # Guassian with positive constrained standard deviation
-    # CMDSTAN=/path/to/cmdstan/ make test_models/gaussian/gaussian_model.so
+    # make test_models/gaussian/gaussian_model.so
 
     model = load_test_model("gaussian")
 
@@ -519,7 +519,7 @@ end
 
 @testset "fr_gaussian" begin
     # Full rank Gaussian
-    # CMDSTAN=/path/to/cmdstan/ make test_models/fr_gaussian/fr_gaussian_model.so
+    # make test_models/fr_gaussian/fr_gaussian_model.so
 
     model = load_test_model("fr_gaussian")
 

--- a/python/bridgestan/__init__.py
+++ b/python/bridgestan/__init__.py
@@ -1,4 +1,4 @@
-from .compile import compile_model, set_bridgestan_path, set_cmdstan_path
+from .compile import compile_model, set_bridgestan_path
 from .model import StanModel
 
-__all__ = ["StanModel", "set_bridgestan_path", "set_cmdstan_path", "compile_model"]
+__all__ = ["StanModel", "set_bridgestan_path", "compile_model"]

--- a/python/bridgestan/compile.py
+++ b/python/bridgestan/compile.py
@@ -31,31 +31,6 @@ MAKE = os.getenv(
 )
 
 BRIDGESTAN_PATH = os.getenv("BRIDGESTAN", str(PYTHON_FOLDER.parent))
-CMDSTAN_PATH = os.getenv("CMDSTAN", "")
-if not CMDSTAN_PATH:
-    try:
-        import cmdstanpy
-
-        CMDSTAN_PATH = cmdstanpy.cmdstan_path()
-    except:
-        try:
-            CMDSTAN_PATH = str(
-                sorted((filter(Path.is_dir, (Path.home() / ".cmdstan").iterdir())))[0]
-            )
-        except:
-            pass
-
-
-def set_cmdstan_path(path: str) -> None:
-    """Set the path to CmdStan used by BridgeStan.
-
-    By default this is set to the value of the environment
-    variable ``CMDSTAN``, or to the newest installation available
-    in ``~/.cmdstan/``.
-    """
-    global CMDSTAN_PATH
-    CMDSTAN_PATH = path
-
 
 def set_bridgestan_path(path: str) -> None:
     """Set the path to BridgeStan.
@@ -82,10 +57,8 @@ def compile_model(stan_file: str, args: List[str] = []) -> Path:
     Run BridgeStan's Makefile on a ``.stan`` file, creating the ``.so``
     used by the StanModel class.
 
-    This function assumes that the paths to BridgeStan and CmdStan
-    are both valid. These can be set with :func:`set_bridgestan_path`
-    and :func:`set_cmdstan_path` if their default values do not
-    match your system configuration.
+    This function assumes that the paths to BridgeStan is valid.
+    This can be set with :func:`set_bridgestan_path`.
 
     :param stan_file: A path to a Stan model file.
     :param args: A list of additional arguments to pass to Make.
@@ -98,20 +71,13 @@ def compile_model(stan_file: str, args: List[str] = []) -> Path:
     """
     verify_bridgestan_path(BRIDGESTAN_PATH)
 
-    if not CMDSTAN_PATH:
-        raise RuntimeError(
-            "Unable to locate CmdStan, you will need to call "
-            "'set_cmdstan_path()' before using compilation features"
-        )
-
     file_path = Path(stan_file).resolve()
     validate_readable(str(file_path))
     if file_path.suffix != ".stan":
         raise ValueError(f"File '{stan_file}' does not end in .stan")
 
     output = generate_so_name(file_path)
-    cmdstan = str(Path(CMDSTAN_PATH).resolve()).replace("\\", "/")
-    cmd = [MAKE, f"CMDSTAN={cmdstan}/"] + args + [str(output)]
+    cmd = [MAKE] + args + [str(output)]
     proc = subprocess.run(
         cmd, cwd=BRIDGESTAN_PATH, capture_output=True, text=True, check=False
     )
@@ -121,11 +87,6 @@ def compile_model(stan_file: str, args: List[str] = []) -> Path:
             f"Command {' '.join(cmd)} failed with code {proc.returncode}.\n"
             f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
         )
-        if "stanc" in error:
-            error += (
-                "\nIf CmdStan is already installed, you may "
-                "need to set the location with set_cmdstan_path()"
-            )
 
         raise RuntimeError(error)
     return output

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -36,18 +36,6 @@ def test_compile_syntax_error():
         bs.compile_model(stanfile)
 
 
-def test_compile_bad_cmdstan():
-    stanfile = STAN_FOLDER / "multi" / "multi.stan"
-    old_path = bs.compile.CMDSTAN_PATH
-    bs.compile.set_cmdstan_path("")
-    with pytest.raises(RuntimeError, match=r"set_cmdstan_path"):
-        bs.compile_model(stanfile)
-    bs.compile.set_cmdstan_path("dummy")
-    with pytest.raises(RuntimeError, match=r"Make sure CmdStan is installed"):
-        bs.compile_model(stanfile)
-    bs.compile.set_cmdstan_path(old_path)
-
-
 def test_compile_bad_bridgestan():
     old_path = bs.compile.BRIDGESTAN_PATH
     with pytest.raises(ValueError, match=r"does not exist"):


### PR DESCRIPTION
This assumes #49 has been merged **first**.

This removes the dependency on CmdStan. BridgeStan now ships with a copy of the Stan repository, and is able to download `stanc` by the same method CmdStan does.

As part of this we need to pick a "blessed" version of Stan to package with BridgeStan. I have picked Stan 2.31.0 for this as it is the latest version, and I imagine we will want to track this as we go along. I will also write up some documentation on how to use custom versions of Stan and Stanc with bridgestan before we merge this. 