### PR TITLE
Prefix any C-exposed symbols with `bs_`

### DIFF
--- a/R/R/bridgestan.R
+++ b/R/R/bridgestan.R
@@ -32,7 +32,7 @@ StanModel <- R6::R6Class("StanModel",
       }
 
       dyn.load(private$lib, PACKAGE = private$lib_name)
-      .C("construct_R",
+      .C("bs_construct_R",
         as.character(data), as.integer(rng_seed), as.integer(chain_id),
         ptr_out = raw(8),
         PACKAGE = private$lib_name
@@ -46,7 +46,7 @@ StanModel <- R6::R6Class("StanModel",
     #' Get the name of this StanModel
     #' @return A character vector of the name.
     name = function() {
-      .C("name_R", as.raw(private$model),
+      .C("bs_name_R", as.raw(private$model),
         name_out = as.character(""),
         PACKAGE = private$lib_name
       )$name_out
@@ -55,7 +55,7 @@ StanModel <- R6::R6Class("StanModel",
     #' Get compile information about this Stan model.
     #' @return A character vector of the Stan version and important flags.
     model_info = function() {
-      .C("model_info_R", as.raw(private$model),
+      .C("bs_model_info_R", as.raw(private$model),
         info_out = as.character(""),
         PACKAGE = private$lib_name
       )$info_out
@@ -71,7 +71,7 @@ StanModel <- R6::R6Class("StanModel",
     #' @param include_gq Whether to include variables from generated quantities.
     #' @return A list of character vectors of the names.
     param_names = function(include_tp = FALSE, include_gq = FALSE) {
-      .C("param_names_R", as.raw(private$model),
+      .C("bs_param_names_R", as.raw(private$model),
         as.logical(include_tp), as.logical(include_gq),
         names_out = as.character(""),
         PACKAGE = private$lib_name
@@ -87,7 +87,7 @@ StanModel <- R6::R6Class("StanModel",
     #' order of the output is column major and more generally last-index major for containers.
     #' @return A list of character vectors of the names.
     param_unc_names = function() {
-      .C("param_unc_names_R", as.raw(private$model),
+      .C("bs_param_unc_names_R", as.raw(private$model),
         names_out = as.character(""),
         PACKAGE = private$lib_name
       )$names_out -> names
@@ -99,7 +99,7 @@ StanModel <- R6::R6Class("StanModel",
     #' @param include_gq Whether to include variables from generated quantities.
     #' @return The number of parameters in the model.
     param_num = function(include_tp = FALSE, include_gq = FALSE) {
-      .C("param_num_R", as.raw(private$model),
+      .C("bs_param_num_R", as.raw(private$model),
         as.logical(include_tp), as.logical(include_gq),
         num = as.integer(0),
         PACKAGE = private$lib_name
@@ -112,7 +112,7 @@ StanModel <- R6::R6Class("StanModel",
     #' For example, `simplex[5]` has a constrained size of 5, but an unconstrained size of 4.
     #' @return The number of parameters in the model.
     param_unc_num = function() {
-      .C("param_unc_num_R", as.raw(private$model),
+      .C("bs_param_unc_num_R", as.raw(private$model),
         num = as.integer(0),
         PACKAGE = private$lib_name
       )$num
@@ -125,7 +125,7 @@ StanModel <- R6::R6Class("StanModel",
     #' @param include_gq Whether to also output the generated quantities of the model.
     #' @return The constrained parameters of the model.
     param_constrain = function(theta_unc, include_tp = FALSE, include_gq = FALSE) {
-      vars <- .C("param_constrain_R", as.raw(private$model),
+      vars <- .C("bs_param_constrain_R", as.raw(private$model),
         as.logical(include_tp), as.logical(include_gq), as.numeric(theta_unc),
         theta = double(self$param_num(include_tp = include_tp, include_gq = include_gq)),
         return_code = as.integer(0),
@@ -146,7 +146,7 @@ StanModel <- R6::R6Class("StanModel",
     #' @param theta The vector of constrained parameters
     #' @return The unconstrained parameters of the model.
     param_unconstrain = function(theta) {
-      vars <- .C("param_unconstrain_R", as.raw(private$model),
+      vars <- .C("bs_param_unconstrain_R", as.raw(private$model),
         as.numeric(theta),
         theta_unc = double(self$param_unc_num()),
         return_code = as.integer(0),
@@ -164,7 +164,7 @@ StanModel <- R6::R6Class("StanModel",
     #' @param json Character vector containing a string representation of JSON data.
     #' @return The unconstrained parameters of the model.
     param_unconstrain_json = function(json) {
-      vars <- .C("param_unconstrain_json_R", as.raw(private$model),
+      vars <- .C("bs_param_unconstrain_json_R", as.raw(private$model),
         as.character(json),
         theta_unc = double(self$param_unc_num()),
         return_code = as.integer(0),
@@ -183,7 +183,7 @@ StanModel <- R6::R6Class("StanModel",
     #' @param jacobian If `TRUE`, include change of variables terms for constrained parameters.
     #' @return The log density.
     log_density = function(theta, propto = TRUE, jacobian = TRUE) {
-      vars <- .C("log_density_R", as.raw(private$model),
+      vars <- .C("bs_log_density_R", as.raw(private$model),
         as.logical(propto), as.logical(jacobian), as.numeric(theta),
         val = double(1),
         return_code = as.integer(0),
@@ -203,7 +203,7 @@ StanModel <- R6::R6Class("StanModel",
     #' @return List containing entries `val` (the log density) and `gradient` (the gradient).
     log_density_gradient = function(theta, propto = TRUE, jacobian = TRUE) {
       dims <- self$param_unc_num()
-      vars <- .C("log_density_gradient_R", as.raw(private$model),
+      vars <- .C("bs_log_density_gradient_R", as.raw(private$model),
         as.logical(propto), as.logical(jacobian), as.numeric(theta),
         val = double(1), gradient = double(dims),
         return_code = as.integer(0),
@@ -223,7 +223,7 @@ StanModel <- R6::R6Class("StanModel",
     #' @return List containing entries `val` (the log density), `gradient` (the gradient), and `hessian` (the Hessian).
     log_density_hessian = function(theta, propto = TRUE, jacobian = TRUE) {
       dims <- self$param_unc_num()
-      vars <- .C("log_density_hessian_R", as.raw(private$model),
+      vars <- .C("bs_log_density_hessian_R", as.raw(private$model),
         as.logical(propto), as.logical(jacobian), as.numeric(theta),
         val = double(1), gradient = double(dims), hess = double(dims * dims),
         return_code = as.integer(0),
@@ -240,7 +240,7 @@ StanModel <- R6::R6Class("StanModel",
     lib_name = NA,
     model = NA,
     finalize = function() {
-      .C("destruct_R",
+      .C("bs_destruct_R",
         as.raw(private$model),
         return_code = as.integer(0),
         PACKAGE = private$lib_name

--- a/R/tests/testthat/test_collisions.c
+++ b/R/tests/testthat/test_collisions.c
@@ -14,7 +14,7 @@ by BridgeStan.
 
 const char *out = "test me";
 
-void name_R(void **unused, char const **name_out)
+void bs_name_R(void **unused, char const **name_out)
 {
   *name_out = out;
 }

--- a/c-example/example.c
+++ b/c-example/example.c
@@ -8,11 +8,11 @@ int main(int argc, char** argv) {
   } else {
     data = "";
   }
-  model_rng* model = construct(data, 123, 0);
+  bs_model_rng* model = bs_construct(data, 123, 0);
   if (!model) {
     return 1;
   }
-  printf("This model's name is %s.\n", name(model));
-  printf("It has %d parameters.\n", param_num(model, 0, 0));
-  return destruct(model);
+  printf("This model's name is %s.\n", bs_name(model));
+  printf("It has %d parameters.\n", bs_param_num(model, 0, 0));
+  return bs_destruct(model);
 }

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -59,7 +59,7 @@ Return the log density of the specified unconstrained parameters.
 This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L351-L358' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L358-L365' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient' href='#BridgeStan.log_density_gradient'>#</a>
 **`BridgeStan.log_density_gradient`** &mdash; *Function*.
@@ -77,7 +77,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L423-L435' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L430-L442' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian' href='#BridgeStan.log_density_hessian'>#</a>
 **`BridgeStan.log_density_hessian`** &mdash; *Function*.
@@ -95,7 +95,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient and Hessian output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L509-L520' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L516-L527' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain' href='#BridgeStan.param_constrain'>#</a>
 **`BridgeStan.param_constrain`** &mdash; *Function*.
@@ -113,7 +113,7 @@ This allocates new memory for the output each call. See `param_constrain!` for a
 This is the inverse of `param_unconstrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L222-L234' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L229-L241' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain' href='#BridgeStan.param_unconstrain'>#</a>
 **`BridgeStan.param_unconstrain`** &mdash; *Function*.
@@ -133,7 +133,7 @@ This allocates new memory for the output each call. See `param_unconstrain!` for
 This is the inverse of `param_constrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L282-L295' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L289-L302' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json' href='#BridgeStan.param_unconstrain_json'>#</a>
 **`BridgeStan.param_unconstrain_json`** &mdash; *Function*.
@@ -151,7 +151,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 This allocates new memory for the output each call. See `param_unconstrain_json!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L335-L345' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L342-L352' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.name' href='#BridgeStan.name'>#</a>
 **`BridgeStan.name`** &mdash; *Function*.
@@ -165,7 +165,7 @@ name(sm)
 Return the name of the model `sm`
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L66-L70' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L73-L77' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.model_info' href='#BridgeStan.model_info'>#</a>
 **`BridgeStan.model_info`** &mdash; *Function*.
@@ -181,7 +181,7 @@ Return information about the model `sm`.
 This includes the Stan version and important compiler flags.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L81-L88' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L88-L95' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_num' href='#BridgeStan.param_num'>#</a>
 **`BridgeStan.param_num`** &mdash; *Function*.
@@ -197,7 +197,7 @@ Return the number of (constrained) parameters in the model.
 This is the total of all the sizes of items declared in the `parameters` block of the model. If `include_tp` or `include_gq` are true, items declared in the `transformed parameters` and `generate quantities` blocks are included, respectively.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L99-L108' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L106-L115' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_num' href='#BridgeStan.param_unc_num'>#</a>
 **`BridgeStan.param_unc_num`** &mdash; *Function*.
@@ -213,7 +213,7 @@ Return the number of unconstrained parameters in the model.
 This function is mainly different from `param_num` when variables are declared with constraints. For example, `simplex[5]` has a constrained size of 5, but an unconstrained size of 4.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L121-L129' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L128-L136' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_names' href='#BridgeStan.param_names'>#</a>
 **`BridgeStan.param_names`** &mdash; *Function*.
@@ -231,7 +231,7 @@ For containers, indexes are separated by periods (.).
 For example, the scalar `a` has indexed name `"a"`, the vector entry `a[1]` has indexed name `"a.1"` and the matrix entry `a[2, 3]` has indexed names `"a.2.3"`. Parameter order of the output is column major and more generally last-index major for containers.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L139-L150' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L146-L157' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_names' href='#BridgeStan.param_unc_names'>#</a>
 **`BridgeStan.param_unc_names`** &mdash; *Function*.
@@ -247,7 +247,7 @@ Return the indexed names of the unconstrained parameters.
 For example, a scalar unconstrained parameter `b` has indexed name `b` and a vector entry `b[3]` has indexed name `b.3`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L163-L170' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L170-L177' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient!' href='#BridgeStan.log_density_gradient!'>#</a>
 **`BridgeStan.log_density_gradient!`** &mdash; *Function*.
@@ -265,7 +265,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out`, and a reference is returned. See `log_density_gradient` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L378-L388' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L385-L395' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian!' href='#BridgeStan.log_density_hessian!'>#</a>
 **`BridgeStan.log_density_hessian!`** &mdash; *Function*.
@@ -283,7 +283,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out_grad` and the Hessian is stored in `out_hess` and references are returned. See `log_density_hessian` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L446-L457' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L453-L464' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain!' href='#BridgeStan.param_constrain!'>#</a>
 **`BridgeStan.param_constrain!`** &mdash; *Function*.
@@ -301,7 +301,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_unconstrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L181-L192' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L188-L199' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain!' href='#BridgeStan.param_unconstrain!'>#</a>
 **`BridgeStan.param_unconstrain!`** &mdash; *Function*.
@@ -321,7 +321,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_constrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L245-L257' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L252-L264' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json!' href='#BridgeStan.param_unconstrain_json!'>#</a>
 **`BridgeStan.param_unconstrain_json!`** &mdash; *Function*.
@@ -339,7 +339,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 The result is stored in the vector `out`, and a reference is returned. See `param_unconstrain_json` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L301-L310' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L308-L317' class='documenter-source'>source</a><br>
 
 
 <a id='Compilation-utilities'></a>
@@ -362,7 +362,7 @@ Run BridgeStan’s Makefile on a `.stan` file, creating the `.so` used by StanMo
 This function assumes that the paths to BridgeStan and CmdStan are both valid. These can be set with `set_bridgestan_path!()` and `set_cmdstan_path!()` if their default values do not match your system configuration.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L66-L77' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L77-L88' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.set_bridgestan_path!' href='#BridgeStan.set_bridgestan_path!'>#</a>
 **`BridgeStan.set_bridgestan_path!`** &mdash; *Function*.
@@ -378,7 +378,7 @@ Set the path BridgeStan.
 By default this is set to the value of the environment variable `BRIDGESTAN`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L52-L59' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L63-L70' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.set_cmdstan_path!' href='#BridgeStan.set_cmdstan_path!'>#</a>
 **`BridgeStan.set_cmdstan_path!`** &mdash; *Function*.
@@ -394,5 +394,5 @@ Set the path to CmdStan used by BridgeStan.
 By default this is set to the value of the environment variable `CMDSTAN`, or to the newest installation available in `~/.cmdstan/`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L36-L43' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L47-L54' class='documenter-source'>source</a><br>
 

--- a/julia/src/BridgeStan.jl
+++ b/julia/src/BridgeStan.jl
@@ -34,5 +34,5 @@ This is equivalent to calling `compile_model` and then the original constructor 
 """
 StanModel(; stan_file::String, data::String = "", seed = 204, chain_id = 0) =
     StanModel(compile_model(stan_file), data, seed, chain_id)
-    
+
 end

--- a/julia/src/compile.jl
+++ b/julia/src/compile.jl
@@ -6,7 +6,9 @@ end
 function get_bridgestan()
     path = get(ENV, "BRIDGESTAN", "")
     if path == ""
-        error("BridgeStan path was not set, compilation will not work until you call `set_bridgestan_path!()`")
+        error(
+            "BridgeStan path was not set, compilation will not work until you call `set_bridgestan_path!()`",
+        )
     end
     return path
 end
@@ -24,7 +26,9 @@ function get_cmdstan()
         end
     end
     if cmdstan == ""
-         error("CmdStan path was not set, compilation will not work until you call `set_cmdstan_path!()`")
+        error(
+            "CmdStan path was not set, compilation will not work until you call `set_cmdstan_path!()`",
+        )
     end
     return cmdstan
 end

--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -31,7 +31,9 @@ mutable struct StanModel
         end
 
         if in(abspath(lib), Libc.Libdl.dllist())
-            @warn "Loading a shared object '" * lib * "' which is already loaded.\n" *
+            @warn "Loading a shared object '" *
+                  lib *
+                  "' which is already loaded.\n" *
                   "If the file has changed since the last time it was loaded, this load may not update the library!"
         end
 

--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -44,7 +44,7 @@ mutable struct StanModel
         lib = Libc.Libdl.dlopen(lib)
 
         stanmodel = ccall(
-            Libc.Libdl.dlsym(lib, "construct"),
+            Libc.Libdl.dlsym(lib, "bs_construct"),
             Ptr{StanModelStruct},
             (Cstring, UInt32, UInt32),
             data,

--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -57,7 +57,7 @@ mutable struct StanModel
 
         function f(sm)
             ccall(
-                Libc.Libdl.dlsym(sm.lib, "destruct"),
+                Libc.Libdl.dlsym(sm.lib, "bs_destruct"),
                 UInt32,
                 (Ptr{StanModelStruct},),
                 sm.stanmodel,
@@ -75,7 +75,7 @@ Return the name of the model `sm`
 """
 function name(sm::StanModel)
     cstr = ccall(
-        Libc.Libdl.dlsym(sm.lib, "name"),
+        Libc.Libdl.dlsym(sm.lib, "bs_name"),
         Cstring,
         (Ptr{StanModelStruct},),
         sm.stanmodel,
@@ -93,7 +93,7 @@ compiler flags.
 """
 function model_info(sm::StanModel)
     cstr = ccall(
-        Libc.Libdl.dlsym(sm.lib, "model_info"),
+        Libc.Libdl.dlsym(sm.lib, "bs_model_info"),
         Cstring,
         (Ptr{StanModelStruct},),
         sm.stanmodel,
@@ -113,7 +113,7 @@ respectively.
 """
 function param_num(sm::StanModel; include_tp = false, include_gq = false)
     ccall(
-        Libc.Libdl.dlsym(sm.lib, "param_num"),
+        Libc.Libdl.dlsym(sm.lib, "bs_param_num"),
         Cint,
         (Ptr{StanModelStruct}, Cint, Cint),
         sm.stanmodel,
@@ -134,7 +134,7 @@ when variables are declared with constraints. For example,
 """
 function param_unc_num(sm::StanModel)
     ccall(
-        Libc.Libdl.dlsym(sm.lib, "param_unc_num"),
+        Libc.Libdl.dlsym(sm.lib, "bs_param_unc_num"),
         Cint,
         (Ptr{StanModelStruct},),
         sm.stanmodel,
@@ -155,7 +155,7 @@ Parameter order of the output is column major and more generally last-index majo
 """
 function param_names(sm::StanModel; include_tp = false, include_gq = false)
     cstr = ccall(
-        Libc.Libdl.dlsym(sm.lib, "param_names"),
+        Libc.Libdl.dlsym(sm.lib, "bs_param_names"),
         Cstring,
         (Ptr{StanModelStruct}, Cint, Cint),
         sm.stanmodel,
@@ -175,7 +175,7 @@ and a vector entry `b[3]` has indexed name `b.3`.
 """
 function param_unc_names(sm::StanModel)
     cstr = ccall(
-        Libc.Libdl.dlsym(sm.lib, "param_unc_names"),
+        Libc.Libdl.dlsym(sm.lib, "bs_param_unc_names"),
         Cstring,
         (Ptr{StanModelStruct},),
         sm.stanmodel,
@@ -209,7 +209,7 @@ function param_constrain!(
         )
     end
     rc = ccall(
-        Libc.Libdl.dlsym(sm.lib, "param_constrain"),
+        Libc.Libdl.dlsym(sm.lib, "bs_param_constrain"),
         Cint,
         (Ptr{StanModelStruct}, Cint, Cint, Ref{Cdouble}, Ref{Cdouble}),
         sm.stanmodel,
@@ -271,7 +271,7 @@ function param_unconstrain!(sm::StanModel, theta::Vector{Float64}, out::Vector{F
     end
 
     rc = ccall(
-        Libc.Libdl.dlsym(sm.lib, "param_unconstrain"),
+        Libc.Libdl.dlsym(sm.lib, "bs_param_unconstrain"),
         Cint,
         (Ptr{StanModelStruct}, Ref{Cdouble}, Ref{Cdouble}),
         sm.stanmodel,
@@ -324,7 +324,7 @@ function param_unconstrain_json!(sm::StanModel, theta::String, out::Vector{Float
     end
 
     rc = ccall(
-        Libc.Libdl.dlsym(sm.lib, "param_unconstrain_json"),
+        Libc.Libdl.dlsym(sm.lib, "bs_param_unconstrain_json"),
         Cint,
         (Ptr{StanModelStruct}, Cstring, Ref{Cdouble}),
         sm.stanmodel,
@@ -364,7 +364,7 @@ and includes change of variables terms for constrained parameters if `jacobian` 
 function log_density(sm::StanModel, q::Vector{Float64}; propto = true, jacobian = true)
     lp = Ref(0.0)
     rc = ccall(
-        Libc.Libdl.dlsym(sm.lib, "log_density"),
+        Libc.Libdl.dlsym(sm.lib, "bs_log_density"),
         Cint,
         (Ptr{StanModelStruct}, Cint, Cint, Ref{Cdouble}, Ref{Cdouble}),
         sm.stanmodel,
@@ -409,7 +409,7 @@ function log_density_gradient!(
     end
 
     rc = ccall(
-        Libc.Libdl.dlsym(sm.lib, "log_density_gradient"),
+        Libc.Libdl.dlsym(sm.lib, "bs_log_density_gradient"),
         Cint,
         (Ptr{StanModelStruct}, Cint, Cint, Ref{Cdouble}, Ref{Cdouble}, Ref{Cdouble}),
         sm.stanmodel,
@@ -485,7 +485,7 @@ function log_density_hessian!(
     end
 
     rc = ccall(
-        Libc.Libdl.dlsym(sm.lib, "log_density_hessian"),
+        Libc.Libdl.dlsym(sm.lib, "bs_log_density_hessian"),
         Cint,
         (
             Ptr{StanModelStruct},

--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -62,7 +62,7 @@ class StanModel:
         self.seed = seed
         self.chain_id = chain_id
 
-        self._construct = self.stanlib.construct
+        self._construct = self.stanlib.bs_construct
         self._construct.restype = ctypes.c_void_p
         self._construct.argtypes = [ctypes.c_char_p, ctypes.c_uint, ctypes.c_uint]
 
@@ -73,23 +73,23 @@ class StanModel:
         if not self.model_rng:
             raise RuntimeError("could not construct model RNG")
 
-        self._name = self.stanlib.name
+        self._name = self.stanlib.bs_name
         self._name.restype = ctypes.c_char_p
         self._name.argtypes = [ctypes.c_void_p]
 
-        self._model_info = self.stanlib.model_info
+        self._model_info = self.stanlib.bs_model_info
         self._model_info.restype = ctypes.c_char_p
         self._model_info.argtypes = [ctypes.c_void_p]
 
-        self._param_num = self.stanlib.param_num
+        self._param_num = self.stanlib.bs_param_num
         self._param_num.restype = ctypes.c_int
         self._param_num.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
 
-        self._param_unc_num = self.stanlib.param_unc_num
+        self._param_unc_num = self.stanlib.bs_param_unc_num
         self._param_unc_num.restype = ctypes.c_int
         self._param_unc_num.argtypes = [ctypes.c_void_p]
 
-        self._param_names = self.stanlib.param_names
+        self._param_names = self.stanlib.bs_param_names
         self._param_names.restype = ctypes.c_char_p
         self._param_names.argtypes = [
             ctypes.c_void_p,
@@ -97,11 +97,11 @@ class StanModel:
             ctypes.c_int,
         ]
 
-        self._param_unc_names = self.stanlib.param_unc_names
+        self._param_unc_names = self.stanlib.bs_param_unc_names
         self._param_unc_names.restype = ctypes.c_char_p
         self._param_unc_names.argtypes = [ctypes.c_void_p]
 
-        self._param_constrain = self.stanlib.param_constrain
+        self._param_constrain = self.stanlib.bs_param_constrain
         self._param_constrain.restype = ctypes.c_int
         self._param_constrain.argtypes = [
             ctypes.c_void_p,
@@ -111,11 +111,11 @@ class StanModel:
             double_array,
         ]
 
-        self._param_unconstrain = self.stanlib.param_unconstrain
+        self._param_unconstrain = self.stanlib.bs_param_unconstrain
         self._param_unconstrain.restype = ctypes.c_int
         self._param_unconstrain.argtypes = [ctypes.c_void_p, double_array, double_array]
 
-        self._param_unconstrain_json = self.stanlib.param_unconstrain_json
+        self._param_unconstrain_json = self.stanlib.bs_param_unconstrain_json
         self._param_unconstrain_json.restype = ctypes.c_int
         self._param_unconstrain_json.argtypes = [
             ctypes.c_void_p,
@@ -123,7 +123,7 @@ class StanModel:
             double_array,
         ]
 
-        self._log_density = self.stanlib.log_density
+        self._log_density = self.stanlib.bs_log_density
         self._log_density.restype = ctypes.c_int
         self._log_density.argtypes = [
             ctypes.c_void_p,
@@ -133,7 +133,7 @@ class StanModel:
             ctypes.POINTER(ctypes.c_double),
         ]
 
-        self._log_density_gradient = self.stanlib.log_density_gradient
+        self._log_density_gradient = self.stanlib.bs_log_density_gradient
         self._log_density_gradient.restype = ctypes.c_int
         self._log_density_gradient.argtypes = [
             ctypes.c_void_p,
@@ -144,7 +144,7 @@ class StanModel:
             double_array,
         ]
 
-        self._log_density_hessian = self.stanlib.log_density_hessian
+        self._log_density_hessian = self.stanlib.bs_log_density_hessian
         self._log_density_hessian.restype = ctypes.c_int
         self._log_density_hessian.argtypes = [
             ctypes.c_void_p,
@@ -156,7 +156,7 @@ class StanModel:
             double_array,
         ]
 
-        self._destruct = self.stanlib.destruct
+        self._destruct = self.stanlib.bs_destruct
         self._destruct.restype = ctypes.c_int
         self._destruct.argtypes = [ctypes.c_void_p]
 

--- a/python/example.py
+++ b/python/example.py
@@ -1,4 +1,3 @@
-
 # REQUIRED IMPORTS
 import bridgestan as bs
 import numpy as np

--- a/src/bridgestan.cpp
+++ b/src/bridgestan.cpp
@@ -2,10 +2,10 @@
 #include "model_rng.cpp"
 #include "bridgestanR.cpp"
 
-model_rng* construct(char* data_file, unsigned int seed,
-                     unsigned int chain_id) {
+bs_model_rng* bs_construct(char* data_file, unsigned int seed,
+                           unsigned int chain_id) {
   try {
-    return new model_rng(data_file, seed, chain_id);
+    return new bs_model_rng(data_file, seed, chain_id);
   } catch (const std::exception& e) {
     std::cerr << "construct(" << data_file << ", " << seed << ", " << chain_id
               << ")"
@@ -18,7 +18,7 @@ model_rng* construct(char* data_file, unsigned int seed,
   return nullptr;
 }
 
-int destruct(model_rng* mr) {
+int bs_destruct(bs_model_rng* mr) {
   try {
     delete (mr);
     return 0;
@@ -28,24 +28,26 @@ int destruct(model_rng* mr) {
   return -1;
 }
 
-const char* name(model_rng* mr) { return mr->name(); }
+const char* bs_name(bs_model_rng* mr) { return mr->name(); }
 
-const char* model_info(model_rng* mr) { return mr->model_info(); }
+const char* bs_model_info(bs_model_rng* mr) { return mr->model_info(); }
 
-const char* param_names(model_rng* mr, bool include_tp, bool include_gq) {
+const char* bs_param_names(bs_model_rng* mr, bool include_tp, bool include_gq) {
   return mr->param_names(include_tp, include_gq);
 }
 
-const char* param_unc_names(model_rng* mr) { return mr->param_unc_names(); }
+const char* bs_param_unc_names(bs_model_rng* mr) {
+  return mr->param_unc_names();
+}
 
-int param_num(model_rng* mr, bool include_tp, bool include_gq) {
+int bs_param_num(bs_model_rng* mr, bool include_tp, bool include_gq) {
   return mr->param_num(include_tp, include_gq);
 }
 
-int param_unc_num(model_rng* mr) { return mr->param_unc_num(); }
+int bs_param_unc_num(bs_model_rng* mr) { return mr->param_unc_num(); }
 
-int param_constrain(model_rng* mr, bool include_tp, bool include_gq,
-                    const double* theta_unc, double* theta) {
+int bs_param_constrain(bs_model_rng* mr, bool include_tp, bool include_gq,
+                       const double* theta_unc, double* theta) {
   try {
     mr->param_constrain(include_tp, include_gq, theta_unc, theta);
     return 0;
@@ -57,7 +59,8 @@ int param_constrain(model_rng* mr, bool include_tp, bool include_gq,
   return 1;
 }
 
-int param_unconstrain(model_rng* mr, const double* theta, double* theta_unc) {
+int bs_param_unconstrain(bs_model_rng* mr, const double* theta,
+                         double* theta_unc) {
   try {
     mr->param_unconstrain(theta, theta_unc);
     return 0;
@@ -69,7 +72,8 @@ int param_unconstrain(model_rng* mr, const double* theta, double* theta_unc) {
   return -1;
 }
 
-int param_unconstrain_json(model_rng* mr, const char* json, double* theta_unc) {
+int bs_param_unconstrain_json(bs_model_rng* mr, const char* json,
+                              double* theta_unc) {
   try {
     mr->param_unconstrain_json(json, theta_unc);
     return 0;
@@ -81,8 +85,8 @@ int param_unconstrain_json(model_rng* mr, const char* json, double* theta_unc) {
   return -1;
 }
 
-int log_density(model_rng* mr, bool propto, bool jacobian,
-                const double* theta_unc, double* val) {
+int bs_log_density(bs_model_rng* mr, bool propto, bool jacobian,
+                   const double* theta_unc, double* val) {
   try {
     mr->log_density(propto, jacobian, theta_unc, val);
     return 0;
@@ -94,8 +98,9 @@ int log_density(model_rng* mr, bool propto, bool jacobian,
   return -1;
 }
 
-int log_density_gradient(model_rng* mr, bool propto, bool jacobian,
-                         const double* theta_unc, double* val, double* grad) {
+int bs_log_density_gradient(bs_model_rng* mr, bool propto, bool jacobian,
+                            const double* theta_unc, double* val,
+                            double* grad) {
   try {
     mr->log_density_gradient(propto, jacobian, theta_unc, val, grad);
     return 0;
@@ -108,9 +113,9 @@ int log_density_gradient(model_rng* mr, bool propto, bool jacobian,
   return -1;
 }
 
-int log_density_hessian(model_rng* mr, bool propto, bool jacobian,
-                        const double* theta_unc, double* val, double* grad,
-                        double* hessian) {
+int bs_log_density_hessian(bs_model_rng* mr, bool propto, bool jacobian,
+                           const double* theta_unc, double* val, double* grad,
+                           double* hessian) {
   try {
     mr->log_density_hessian(propto, jacobian, theta_unc, val, grad, hessian);
     return 0;

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -5,7 +5,7 @@
 #include "model_rng.hpp"
 extern "C" {
 #else
-typedef struct model_rng model_rng;
+typedef struct bs_model_rng bs_model_rng;
 typedef int bool;
 #endif
 /**
@@ -20,7 +20,8 @@ typedef int bool;
  * @return pointer to constructed model or `nullptr` if construction
  * fails
  */
-model_rng* construct(char* data_file, unsigned int seed, unsigned int chain_id);
+bs_model_rng* bs_construct(char* data_file, unsigned int seed,
+                           unsigned int chain_id);
 
 /**
  * Destroy the model and return 0 for success and -1 if there is an
@@ -30,7 +31,7 @@ model_rng* construct(char* data_file, unsigned int seed, unsigned int chain_id);
  * @return 0 for success and -1 if there is an exception freeing one
  * of the model components.
  */
-int destruct(model_rng* mr);
+int bs_destruct(bs_model_rng* mr);
 
 /**
  * Return the name of the specified model as a C-style string.
@@ -41,7 +42,7 @@ int destruct(model_rng* mr);
  * @param[in] mr pointer to model and RNG structure
  * @return name of model
  */
-const char* name(model_rng* mr);
+const char* bs_name(bs_model_rng* mr);
 
 /**
  * Return information about the compiled model as a C-style string.
@@ -53,7 +54,7 @@ const char* name(model_rng* mr);
  * @return Information about the model including Stan version, Stan defines, and
  * compiler flags.
  */
-const char* model_info(model_rng* mr);
+const char* bs_model_info(bs_model_rng* mr);
 
 /**
  * Return a comma-separated sequence of indexed parameter names,
@@ -74,7 +75,7 @@ const char* model_info(model_rng* mr);
  * @param[in] include_gq `true` to include generated quantities
  * @return CSV-separated, indexed, parameter names
  */
-const char* param_names(model_rng* mr, bool include_tp, bool include_gq);
+const char* bs_param_names(bs_model_rng* mr, bool include_tp, bool include_gq);
 
 /**
  * Return a comma-separated sequence of unconstrained parameters.
@@ -93,7 +94,7 @@ const char* param_names(model_rng* mr, bool include_tp, bool include_gq);
  * @param[in] mr pointer to model and RNG structure
  * @return CSV-separated, indexed, unconstrained parameter names
  */
-const char* param_unc_names(model_rng* mr);
+const char* bs_param_unc_names(bs_model_rng* mr);
 
 /**
  * Return the number of scalar parameters, optionally including the
@@ -105,7 +106,7 @@ const char* param_unc_names(model_rng* mr);
  * @param[in] include_gq `true` to include generated quantities
  * @return number of parameters
  */
-int param_num(model_rng* mr, bool include_tp, bool include_gq);
+int bs_param_num(bs_model_rng* mr, bool include_tp, bool include_gq);
 
 /**
  * Return the number of unconstrained parameters.  The number of
@@ -116,7 +117,7 @@ int param_num(model_rng* mr, bool include_tp, bool include_gq);
  * @param[in] mr pointer to model and RNG structure
  * @return number of unconstrained parameters
  */
-int param_unc_num(model_rng* mr);
+int bs_param_unc_num(bs_model_rng* mr);
 
 /**
  * Set the sequence of constrained parameters based on the specified
@@ -134,8 +135,8 @@ int param_unc_num(model_rng* mr);
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int param_constrain(model_rng* mr, bool include_tp, bool include_gq,
-                    const double* theta_unc, double* theta);
+int bs_param_constrain(bs_model_rng* mr, bool include_tp, bool include_gq,
+                       const double* theta_unc, double* theta);
 
 /**
  * Set the sequence of unconstrained parameters based on the
@@ -150,7 +151,8 @@ int param_constrain(model_rng* mr, bool include_tp, bool include_gq,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int param_unconstrain(model_rng* mr, const double* theta, double* theta_unc);
+int bs_param_unconstrain(bs_model_rng* mr, const double* theta,
+                         double* theta_unc);
 
 /**
  * Set the sequence of unconstrained parameters based on the JSON
@@ -166,7 +168,8 @@ int param_unconstrain(model_rng* mr, const double* theta, double* theta_unc);
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int param_unconstrain_json(model_rng* mr, const char* json, double* theta_unc);
+int bs_param_unconstrain_json(bs_model_rng* mr, const char* json,
+                              double* theta_unc);
 
 /**
  * Set the log density of the specified parameters, dropping
@@ -183,8 +186,8 @@ int param_unconstrain_json(model_rng* mr, const char* json, double* theta_unc);
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int log_density(model_rng* mr, bool propto, bool jacobian, const double* theta,
-                double* lp);
+int bs_log_density(bs_model_rng* mr, bool propto, bool jacobian,
+                   const double* theta, double* lp);
 
 /**
  * Set the log density and gradient of the specified parameters,
@@ -205,8 +208,8 @@ int log_density(model_rng* mr, bool propto, bool jacobian, const double* theta,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int log_density_gradient(model_rng* mr, bool propto, bool jacobian,
-                         const double* theta, double* val, double* grad);
+int bs_log_density_gradient(bs_model_rng* mr, bool propto, bool jacobian,
+                            const double* theta, double* val, double* grad);
 
 /**
  * Set the log density, gradient, and Hessian of the specified parameters,
@@ -229,9 +232,9 @@ int log_density_gradient(model_rng* mr, bool propto, bool jacobian,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int log_density_hessian(model_rng* mr, bool propto, bool jacobian,
-                        const double* theta, double* val, double* grad,
-                        double* hessian);
+int bs_log_density_hessian(bs_model_rng* mr, bool propto, bool jacobian,
+                           const double* theta, double* val, double* grad,
+                           double* hessian);
 
 #ifdef __cplusplus
 }

--- a/src/bridgestanR.cpp
+++ b/src/bridgestanR.cpp
@@ -1,58 +1,58 @@
 #include "bridgestanR.h"
 
-void construct_R(char** data, int* rng, int* chain, model_rng** ptr_out) {
-  *ptr_out = construct(*data, *rng, *chain);
+void bs_construct_R(char** data, int* rng, int* chain, bs_model_rng** ptr_out) {
+  *ptr_out = bs_construct(*data, *rng, *chain);
 }
-void destruct_R(model_rng** model, int* return_code) {
-  *return_code = destruct(*model);
+void bs_destruct_R(bs_model_rng** model, int* return_code) {
+  *return_code = bs_destruct(*model);
 }
-void name_R(model_rng** model, char const** name_out) {
-  *name_out = name(*model);
+void bs_name_R(bs_model_rng** model, char const** name_out) {
+  *name_out = bs_name(*model);
 }
-void model_info_R(model_rng** model, char const** info_out){
-  *info_out = model_info(*model);
+void bs_model_info_R(bs_model_rng** model, char const** info_out) {
+  *info_out = bs_model_info(*model);
 }
-void param_names_R(model_rng** model, int* include_tp, int* include_gq,
-                   char const** names_out) {
-  *names_out = param_names(*model, *include_tp, *include_gq);
+void bs_param_names_R(bs_model_rng** model, int* include_tp, int* include_gq,
+                      char const** names_out) {
+  *names_out = bs_param_names(*model, *include_tp, *include_gq);
 }
-void param_unc_names_R(model_rng** model, char const** names_out) {
-  *names_out = param_unc_names(*model);
+void bs_param_unc_names_R(bs_model_rng** model, char const** names_out) {
+  *names_out = bs_param_unc_names(*model);
 }
-void param_num_R(model_rng** model, int* include_tp, int* include_gq,
-                 int* num_out) {
-  *num_out = param_num(*model, *include_tp, *include_gq);
+void bs_param_num_R(bs_model_rng** model, int* include_tp, int* include_gq,
+                    int* num_out) {
+  *num_out = bs_param_num(*model, *include_tp, *include_gq);
 }
-void param_unc_num_R(model_rng** model, int* num_out) {
-  *num_out = param_unc_num(*model);
+void param_unc_num_R(bs_model_rng** model, int* num_out) {
+  *num_out = bs_param_unc_num(*model);
 }
-void param_constrain_R(model_rng** model, int* include_tp, int* include_gq,
-                       const double* theta_unc, double* theta,
-                       int* return_code) {
+void bs_param_constrain_R(bs_model_rng** model, int* include_tp,
+                          int* include_gq, const double* theta_unc,
+                          double* theta, int* return_code) {
   *return_code
-      = param_constrain(*model, *include_tp, *include_gq, theta_unc, theta);
+      = bs_param_constrain(*model, *include_tp, *include_gq, theta_unc, theta);
 }
-void param_unconstrain_R(model_rng** model, const double* theta,
-                         double* theta_unc, int* return_code) {
-  *return_code = param_unconstrain(*model, theta, theta_unc);
+void bs_param_unconstrain_R(bs_model_rng** model, const double* theta,
+                            double* theta_unc, int* return_code) {
+  *return_code = bs_param_unconstrain(*model, theta, theta_unc);
 }
-void param_unconstrain_json_R(model_rng** model, char const** json,
-                              double* theta_unc, int* return_code) {
-  *return_code = param_unconstrain_json(*model, *json, theta_unc);
+void bs_param_unconstrain_json_R(bs_model_rng** model, char const** json,
+                                 double* theta_unc, int* return_code) {
+  *return_code = bs_param_unconstrain_json(*model, *json, theta_unc);
 }
-void log_density_R(model_rng** model, int* propto, int* jacobian,
-                   const double* theta, double* val, int* return_code) {
-  *return_code = log_density(*model, *propto, *jacobian, theta, val);
+void bs_log_density_R(bs_model_rng** model, int* propto, int* jacobian,
+                      const double* theta, double* val, int* return_code) {
+  *return_code = bs_log_density(*model, *propto, *jacobian, theta, val);
 }
-void log_density_gradient_R(model_rng** model, int* propto, int* jacobian,
-                            const double* theta, double* val, double* grad,
-                            int* return_code) {
+void bs_log_density_gradient_R(bs_model_rng** model, int* propto, int* jacobian,
+                               const double* theta, double* val, double* grad,
+                               int* return_code) {
   *return_code
-      = log_density_gradient(*model, *propto, *jacobian, theta, val, grad);
+      = bs_log_density_gradient(*model, *propto, *jacobian, theta, val, grad);
 }
-void log_density_hessian_R(model_rng** model, int* propto, int* jacobian,
-                           const double* theta, double* val, double* grad,
-                           double* hess, int* return_code) {
-  *return_code
-      = log_density_hessian(*model, *propto, *jacobian, theta, val, grad, hess);
+void bs_log_density_hessian_R(bs_model_rng** model, int* propto, int* jacobian,
+                              const double* theta, double* val, double* grad,
+                              double* hess, int* return_code) {
+  *return_code = bs_log_density_hessian(*model, *propto, *jacobian, theta, val,
+                                        grad, hess);
 }

--- a/src/bridgestanR.cpp
+++ b/src/bridgestanR.cpp
@@ -23,7 +23,7 @@ void bs_param_num_R(bs_model_rng** model, int* include_tp, int* include_gq,
                     int* num_out) {
   *num_out = bs_param_num(*model, *include_tp, *include_gq);
 }
-void param_unc_num_R(bs_model_rng** model, int* num_out) {
+void bs_param_unc_num_R(bs_model_rng** model, int* num_out) {
   *num_out = bs_param_unc_num(*model);
 }
 void bs_param_constrain_R(bs_model_rng** model, int* include_tp,

--- a/src/bridgestanR.h
+++ b/src/bridgestanR.h
@@ -5,50 +5,50 @@
 #include "model_rng.hpp"
 extern "C" {
 #else
-typedef struct model_rng model_rng;
+typedef struct bs_model_rng bs_model_rng;
 typedef int bool;
 #endif
 
 // Shim to convert to R interface requirement of void with pointer args
 // All calls directly delegated to versions without _R suffix
-void construct_R(char** data, int* rng, int* chain, model_rng** ptr_out);
+void bs_construct_R(char** data, int* rng, int* chain, bs_model_rng** ptr_out);
 
-void destruct_R(model_rng** model, int* return_code);
+void bs_destruct_R(bs_model_rng** model, int* return_code);
 
-void name_R(model_rng** model, char const** name_out);
+void bs_name_R(bs_model_rng** model, char const** name_out);
 
-void model_info_R(model_rng** model, char const** info_out);
+void bs_model_info_R(bs_model_rng** model, char const** info_out);
 
-void param_names_R(model_rng** model, int* include_tp, int* include_gq,
-                   char const** name_out);
+void bs_param_names_R(bs_model_rng** model, int* include_tp, int* include_gq,
+                      char const** name_out);
 
-void param_unc_names_R(model_rng** model, char const** name_out);
+void bs_param_unc_names_R(bs_model_rng** model, char const** name_out);
 
-void param_num_R(model_rng** model, int* include_tp, int* include_gq,
-                 int* num_out);
+void bs_param_num_R(bs_model_rng** model, int* include_tp, int* include_gq,
+                    int* num_out);
 
-void param_unc_num_R(model_rng** model, int* num_out);
+void bs_param_unc_num_R(bs_model_rng** model, int* num_out);
 
-void param_constrain_R(model_rng** model, int* include_tp, int* include_gq,
-                       const double* theta_unc, double* theta,
-                       int* return_code);
+void bs_param_constrain_R(bs_model_rng** model, int* include_tp,
+                          int* include_gq, const double* theta_unc,
+                          double* theta, int* return_code);
 
-void param_unconstrain_R(model_rng** model, const double* theta,
-                         double* theta_unc, int* return_code);
+void bs_param_unconstrain_R(bs_model_rng** model, const double* theta,
+                            double* theta_unc, int* return_code);
 
-void param_unconstrain_json_R(model_rng** model, char const** json,
-                              double* theta_unc, int* return_code);
+void bs_param_unconstrain_json_R(bs_model_rng** model, char const** json,
+                                 double* theta_unc, int* return_code);
 
-void log_density_R(model_rng** model, int* propto, int* jacobian,
-                   const double* theta, double* val, int* return_code);
+void bs_log_density_R(bs_model_rng** model, int* propto, int* jacobian,
+                      const double* theta, double* val, int* return_code);
 
-void log_density_gradient_R(model_rng** model, int* propto, int* jacobian,
-                            const double* theta, double* val, double* grad,
-                            int* return_code);
+void bs_log_density_gradient_R(bs_model_rng** model, int* propto, int* jacobian,
+                               const double* theta, double* val, double* grad,
+                               int* return_code);
 
-void log_density_hessian_R(model_rng** model, int* propto, int* jacobian,
-                           const double* theta, double* val, double* grad,
-                           double* hess, int* return_code);
+void bs_log_density_hessian_R(bs_model_rng** model, int* propto, int* jacobian,
+                              const double* theta, double* val, double* grad,
+                              double* hess, int* return_code);
 
 #ifdef __cplusplus
 }

--- a/src/model_rng.hpp
+++ b/src/model_rng.hpp
@@ -12,7 +12,7 @@
  * CSV format.  Instances can be constructed with the C function
  * `construct()` and destroyed with the C function `destruct()`.
  */
-class model_rng {
+class bs_model_rng {
  public:
   /**
    * Construct a model and random number generator with cached
@@ -23,12 +23,12 @@ class model_rng {
    * @param[in] chain_id number of gaps to skip in the pseudorandom
    * number generator for concurrent computations
    */
-  model_rng(const char* data_file, unsigned int seed, unsigned int chain_id);
+  bs_model_rng(const char* data_file, unsigned int seed, unsigned int chain_id);
 
   /**
    * Destroy this object and free all of the memory allocated for it.
    */
-  ~model_rng();
+  ~bs_model_rng();
 
   /**
    * Return the name of the model.  This class manages the memory,


### PR DESCRIPTION
Closes #53.

This is a breaking change for the C API, but not for any of the higher level APIs. 