### PR TITLE
Compile methods: split stanc args from make args, add default include path

### DIFF
--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -354,15 +354,15 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 
 
 ```julia
-compile_model(stan_file, args=[])
+compile_model(stan_file; stanc_args=[], make_args=[])
 ```
 
-Run BridgeStan’s Makefile on a `.stan` file, creating the `.so` used by StanModel and return a path to the compiled library. Additional arguments to `make` can be passed as a vector, for example `["STAN_THREADS=true"]` enables the model's threading capabilities.
+Run BridgeStan’s Makefile on a `.stan` file, creating the `.so` used by StanModel and return a path to the compiled library. Arguments to `stanc3` can be passed as a vector, for example `["--O1"]` enables level 1 compiler optimizations. Additional arguments to `make` can be passed as a vector, for example `["STAN_THREADS=true"]` enables the model's threading capabilities.
 
 This function assumes that the path to BridgeStan is valid. This can be set with `set_bridgestan_path!()`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L42-L52' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L42-L54' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.set_bridgestan_path!' href='#BridgeStan.set_bridgestan_path!'>#</a>
 **`BridgeStan.set_bridgestan_path!`** &mdash; *Function*.

--- a/julia/src/BridgeStan.jl
+++ b/julia/src/BridgeStan.jl
@@ -25,13 +25,19 @@ include("model.jl")
 include("compile.jl")
 
 """
-    StanModel(;stan_file, data="", seed=204, chain_id=0)
+    StanModel(;stan_file, stanc_args=[], make_args=[], data="", seed=204, chain_id=0)
 
 Construct a StanModel instance from a `.stan` file, compiling if necessary.
 
 This is equivalent to calling `compile_model` and then the original constructor of StanModel.
 """
-StanModel(; stan_file::String, data::String="", seed=204, chain_id=0) =
-    StanModel(compile_model(stan_file), data, seed, chain_id)
+StanModel(;
+    stan_file::String,
+    stanc_args::AbstractVector{String} = String[],
+    make_args::AbstractVector{String} = String[],
+    data::String = "",
+    seed = 204,
+    chain_id = 0,
+) = StanModel(compile_model(stan_file; stanc_args, make_args), data, seed, chain_id)
 
 end

--- a/julia/src/compile.jl
+++ b/julia/src/compile.jl
@@ -40,17 +40,23 @@ end
 
 
 """
-    compile_model(stan_file, args=[])
+    compile_model(stan_file; stanc_args=[], make_args=[])
 
 Run BridgeStan’s Makefile on a `.stan` file, creating the `.so` used by StanModel and
 return a path to the compiled library.
+Arguments to `stanc3` can be passed as a vector, for example `["--O1"]` enables level 1 compiler
+optimizations.
 Additional arguments to `make` can be passed as a vector, for example `["STAN_THREADS=true"]`
 enables the model's threading capabilities.
 
 This function assumes that the path to BridgeStan is valid.
 This can be set with `set_bridgestan_path!()`.
 """
-function compile_model(stan_file::AbstractString, args::AbstractVector{String}=String[])
+function compile_model(
+    stan_file::AbstractString;
+    stanc_args::AbstractVector{String} = String[],
+    make_args::AbstractVector{String} = String[],
+)
     bridgestan = get_bridgestan()
     validate_stan_dir(bridgestan)
 
@@ -64,11 +70,13 @@ function compile_model(stan_file::AbstractString, args::AbstractVector{String}=S
     absolute_path = abspath(stan_file)
     output_file = splitext(absolute_path)[1] * "_model.so"
 
-    cmd =
-        Cmd(`$(get_make()) $args $output_file`, dir=abspath(bridgestan))
+    cmd = Cmd(
+        `$(get_make()) $make_args STANCFLAGS="$stanc_args --include-paths=." $output_file`,
+        dir = abspath(bridgestan),
+    )
     out = IOBuffer()
     err = IOBuffer()
-    is_ok = success(pipeline(cmd; stdout=out, stderr=err))
+    is_ok = success(pipeline(cmd; stdout = out, stderr = err))
     if !is_ok
         error(
             "Compilation failed!\nCommand: $cmd\nstdout: $(String(take!(out)))\nstderr: $(String(take!(err)))",

--- a/julia/test/compile_tests.jl
+++ b/julia/test/compile_tests.jl
@@ -14,7 +14,7 @@ models = joinpath(@__DIR__, "../../test_models/")
     @test Base.samefile(lib, res)
 
     rm(lib)
-    res = BridgeStan.compile_model(stanfile, ["STAN_THREADS=true"])
+    res = BridgeStan.compile_model(stanfile; make_args = ["STAN_THREADS=true"])
     @test Base.samefile(lib, res)
 end
 

--- a/python/bridgestan/compile.py
+++ b/python/bridgestan/compile.py
@@ -32,6 +32,7 @@ MAKE = os.getenv(
 
 BRIDGESTAN_PATH = os.getenv("BRIDGESTAN", str(PYTHON_FOLDER.parent))
 
+
 def set_bridgestan_path(path: str) -> None:
     """Set the path to BridgeStan.
 
@@ -52,7 +53,9 @@ def generate_so_name(model: Path):
     return model.with_stem(f"{name}_model").with_suffix(".so")
 
 
-def compile_model(stan_file: str, args: List[str] = []) -> Path:
+def compile_model(
+    stan_file: str, *, stanc_args: List[str] = [], make_args: List[str] = []
+) -> Path:
     """
     Run BridgeStan's Makefile on a ``.stan`` file, creating the ``.so``
     used by the StanModel class.
@@ -61,7 +64,9 @@ def compile_model(stan_file: str, args: List[str] = []) -> Path:
     This can be set with :func:`set_bridgestan_path`.
 
     :param stan_file: A path to a Stan model file.
-    :param args: A list of additional arguments to pass to Make.
+    :param stanc_args: A list of arguments to pass to stanc3.
+        For example, ``["--O1"]`` will enable compiler optimization level 1.
+    :param make_args: A list of additional arguments to pass to Make.
         For example, ``["STAN_THREADS=True"]`` will enable
         threading for the compiled model.
     :raises FileNotFoundError or PermissionError: If `stan_file` does not exist
@@ -76,8 +81,14 @@ def compile_model(stan_file: str, args: List[str] = []) -> Path:
     if file_path.suffix != ".stan":
         raise ValueError(f"File '{stan_file}' does not end in .stan")
 
+    stanc_args
     output = generate_so_name(file_path)
-    cmd = [MAKE] + args + [str(output)]
+    cmd = (
+        [MAKE]
+        + make_args
+        + ['STANCFLAGS="' + " ".join(stanc_args + ["--include-paths=."]) + '"']
+        + [str(output)]
+    )
     proc = subprocess.run(
         cmd, cwd=BRIDGESTAN_PATH, capture_output=True, text=True, check=False
     )

--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -166,6 +166,8 @@ class StanModel:
         stan_file: str,
         model_data: Optional[str] = None,
         *,
+        stanc_args: List[str] = [],
+        make_args: List[str] = [],
         seed: int = 1234,
         chain_id: int = 0,
     ):
@@ -177,6 +179,11 @@ class StanModel:
 
         :param stan_file: A path to a Stan model file.
         :param model_data: A path to data in JSON format.
+        :param stanc_args: A list of arguments to pass to stanc3.
+            For example, ``["--O1"]`` will enable compiler optimization level 1.
+        :param make_args: A list of additional arguments to pass to Make.
+            For example, ``["STAN_THREADS=True"]`` will enable
+            threading for the compiled model.
         :param seed: A pseudo random number generator seed.
         :param chain_id: A unique identifier for concurrent chains of
             pseudorandom numbers.
@@ -185,7 +192,7 @@ class StanModel:
         :raises ValueError: If BridgeStan cannot be located.
         :raises RuntimeError: If compilation fails.
         """
-        result = compile_model(stan_file)
+        result = compile_model(stan_file, stanc_args=stanc_args, make_args=make_args)
         return cls(str(result), model_data, seed=seed, chain_id=chain_id)
 
     def __del__(self) -> None:

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -11,10 +11,10 @@ def test_compile_good():
     stanfile = STAN_FOLDER / "multi" / "multi.stan"
     lib = bs.compile.generate_so_name(stanfile)
     lib.unlink(missing_ok=True)
-    res = bs.compile_model(stanfile)
+    res = bs.compile_model(stanfile, stanc_args=["--O1"])
     assert lib.samefile(res)
     lib.unlink()
-    res = bs.compile_model(stanfile, args=["STAN_THREADS=true"])
+    res = bs.compile_model(stanfile, make_args=["STAN_THREADS=true"])
     assert lib.samefile(res)
 
 


### PR DESCRIPTION
Closes #56.

This changes the Python and Julia `compile_model` methods and their associated constructors of the StanModel objects to allow you to specify arguments for `make` and `stanc3`. Additionally, mirroring cmdstanpy and cmdstanr, we add the current working directory as a default include path. 