### PR TITLE
Allow JSON data as a string

### DIFF
--- a/R/R/bridgestan.R
+++ b/R/R/bridgestan.R
@@ -10,7 +10,7 @@ StanModel <- R6::R6Class("StanModel",
     #' @description
     #' Create a Stan Model instace.
     #' @param lib A path to a compiled BridgeStan Shared Object file.
-    #' @param data A path to a JSON data file for the model.
+    #' @param data Either a string representation of a JSON object or a path to a data file in JSON format ending in ".json".
     #' @param rng_seed Seed for the RNG in the model object.
     #' @param chain_id Used to offset the RNG by a fixed amount.
     #' @return A new StanModel.

--- a/R/man/StanModel.Rd
+++ b/R/man/StanModel.Rd
@@ -46,7 +46,7 @@ Create a Stan Model instace.
 \describe{
 \item{\code{lib}}{A path to a compiled BridgeStan Shared Object file.}
 
-\item{\code{data}}{A path to a JSON data file for the model.}
+\item{\code{data}}{Either a string representation of a JSON object or a path to a data file in JSON format ending in ".json".}
 
 \item{\code{rng_seed}}{Seed for the RNG in the model object.}
 

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -93,7 +93,7 @@ StanModel(lib, datafile="", seed=204, chain_id=0)
 
 A StanModel instance encapsulates a Stan model instantiated with data.
 
-The constructor a Stan model from the supplied library file path and data file path. If seed or chain_id are supplied, these are used to initialize the RNG used by the model.
+The constructor a Stan model from the supplied library file path and data. Data should either be a string containing a JSON object or a path to a data file ending in `.json`. If seed or chain_id are supplied, these are used to initialize the RNG used by the model.
 
 ```
 StanModel(;stan_file, data="", seed=204, chain_id=0)
@@ -104,7 +104,7 @@ Construct a StanModel instance from a `.stan` file, compiling if necessary.
 This is equivalent to calling `compile_model` and then the original constructor of StanModel.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L4-L17' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L4-L18' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density' href='#BridgeStan.log_density'>#</a>
 **`BridgeStan.log_density`** &mdash; *Function*.
@@ -120,7 +120,7 @@ Return the log density of the specified unconstrained parameters.
 This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L358-L365' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L359-L366' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient' href='#BridgeStan.log_density_gradient'>#</a>
 **`BridgeStan.log_density_gradient`** &mdash; *Function*.
@@ -138,7 +138,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L430-L442' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L431-L443' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian' href='#BridgeStan.log_density_hessian'>#</a>
 **`BridgeStan.log_density_hessian`** &mdash; *Function*.
@@ -156,7 +156,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient and Hessian output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L516-L527' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L517-L528' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain' href='#BridgeStan.param_constrain'>#</a>
 **`BridgeStan.param_constrain`** &mdash; *Function*.
@@ -174,7 +174,7 @@ This allocates new memory for the output each call. See `param_constrain!` for a
 This is the inverse of `param_unconstrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L229-L241' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L230-L242' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain' href='#BridgeStan.param_unconstrain'>#</a>
 **`BridgeStan.param_unconstrain`** &mdash; *Function*.
@@ -194,7 +194,7 @@ This allocates new memory for the output each call. See `param_unconstrain!` for
 This is the inverse of `param_constrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L289-L302' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L290-L303' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json' href='#BridgeStan.param_unconstrain_json'>#</a>
 **`BridgeStan.param_unconstrain_json`** &mdash; *Function*.
@@ -212,7 +212,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 This allocates new memory for the output each call. See `param_unconstrain_json!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L342-L352' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L343-L353' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.name' href='#BridgeStan.name'>#</a>
 **`BridgeStan.name`** &mdash; *Function*.
@@ -226,7 +226,7 @@ name(sm)
 Return the name of the model `sm`
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L73-L77' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L74-L78' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.model_info' href='#BridgeStan.model_info'>#</a>
 **`BridgeStan.model_info`** &mdash; *Function*.
@@ -242,7 +242,7 @@ Return information about the model `sm`.
 This includes the Stan version and important compiler flags.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L88-L95' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L89-L96' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_num' href='#BridgeStan.param_num'>#</a>
 **`BridgeStan.param_num`** &mdash; *Function*.
@@ -258,7 +258,7 @@ Return the number of (constrained) parameters in the model.
 This is the total of all the sizes of items declared in the `parameters` block of the model. If `include_tp` or `include_gq` are true, items declared in the `transformed parameters` and `generate quantities` blocks are included, respectively.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L106-L115' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L107-L116' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_num' href='#BridgeStan.param_unc_num'>#</a>
 **`BridgeStan.param_unc_num`** &mdash; *Function*.
@@ -274,7 +274,7 @@ Return the number of unconstrained parameters in the model.
 This function is mainly different from `param_num` when variables are declared with constraints. For example, `simplex[5]` has a constrained size of 5, but an unconstrained size of 4.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L128-L136' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L129-L137' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_names' href='#BridgeStan.param_names'>#</a>
 **`BridgeStan.param_names`** &mdash; *Function*.
@@ -292,7 +292,7 @@ For containers, indexes are separated by periods (.).
 For example, the scalar `a` has indexed name `"a"`, the vector entry `a[1]` has indexed name `"a.1"` and the matrix entry `a[2, 3]` has indexed names `"a.2.3"`. Parameter order of the output is column major and more generally last-index major for containers.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L146-L157' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L147-L158' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_names' href='#BridgeStan.param_unc_names'>#</a>
 **`BridgeStan.param_unc_names`** &mdash; *Function*.
@@ -308,7 +308,7 @@ Return the indexed names of the unconstrained parameters.
 For example, a scalar unconstrained parameter `b` has indexed name `b` and a vector entry `b[3]` has indexed name `b.3`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L170-L177' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L171-L178' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient!' href='#BridgeStan.log_density_gradient!'>#</a>
 **`BridgeStan.log_density_gradient!`** &mdash; *Function*.
@@ -326,7 +326,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out`, and a reference is returned. See `log_density_gradient` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L385-L395' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L386-L396' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian!' href='#BridgeStan.log_density_hessian!'>#</a>
 **`BridgeStan.log_density_hessian!`** &mdash; *Function*.
@@ -344,7 +344,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out_grad` and the Hessian is stored in `out_hess` and references are returned. See `log_density_hessian` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L453-L464' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L454-L465' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain!' href='#BridgeStan.param_constrain!'>#</a>
 **`BridgeStan.param_constrain!`** &mdash; *Function*.
@@ -362,7 +362,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_unconstrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L188-L199' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L189-L200' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain!' href='#BridgeStan.param_unconstrain!'>#</a>
 **`BridgeStan.param_unconstrain!`** &mdash; *Function*.
@@ -382,7 +382,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_constrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L252-L264' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L253-L265' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json!' href='#BridgeStan.param_unconstrain_json!'>#</a>
 **`BridgeStan.param_unconstrain_json!`** &mdash; *Function*.
@@ -400,7 +400,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 The result is stored in the vector `out`, and a reference is returned. See `param_unconstrain_json` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L308-L317' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L309-L318' class='documenter-source'>source</a><br>
 
 
 <a id='Compilation-utilities'></a>

--- a/docs/languages/r.md
+++ b/docs/languages/r.md
@@ -70,7 +70,7 @@ _Arguments_
 
   - `lib` A path to a compiled BridgeStan Shared Object file.
 
-  - `data` A path to a JSON data file for the model.
+  - `data` Either a string representation of a JSON object or a path to a data file in JSON format ending in ".json".
 
   - `rng_seed` Seed for the RNG in the model object.
 

--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -6,7 +6,8 @@ mutable struct StanModelStruct end
 
 A StanModel instance encapsulates a Stan model instantiated with data.
 
-The constructor a Stan model from the supplied library file path and data file path.
+The constructor a Stan model from the supplied library file path and data. Data
+should either be a string containing a JSON object or a path to a data file ending in `.json`.
 If seed or chain_id are supplied, these are used to initialize the RNG used by the model.
 
     StanModel(;stan_file, data="", seed=204, chain_id=0)
@@ -37,7 +38,7 @@ mutable struct StanModel
                   "If the file has changed since the last time it was loaded, this load may not update the library!"
         end
 
-        if data != "" && !isfile(data)
+        if data != "" && endswith(data, ".json") && !isfile(data)
             throw(SystemError("Data file not found"))
         end
 

--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -22,7 +22,8 @@ class StanModel:
     return values.  The constructor arguments are
 
     :param model_lib: A path to a compiled shared object.
-    :param model_data: A path to data in JSON format.
+    :param model_data: Either a string representation of a JSON object or a
+         path to a data file in JSON format ending in ``.json``.
     :param seed: A pseudo random number generator seed.
     :param chain_id: A unique identifier for concurrent chains of
         pseudorandom numbers.
@@ -44,7 +45,8 @@ class StanModel:
         constructor arguments.
 
         :param model_lib: A system path to compiled shared object.
-        :param model_data: A system path to a JSON data file.
+        :param model_data: Either a string representation of a JSON object or a
+            system path to a data file in JSON format ending in ``.json``.
         :param seed: A pseudo random number generator seed.
         :param chain_id: A unique identifier for concurrent chains of
             pseudorandom numbers.
@@ -54,7 +56,7 @@ class StanModel:
             model from C++.
         """
         validate_readable(model_lib)
-        if not model_data is None:
+        if not model_data is None and model_data.endswith('.json'):
             validate_readable(model_data)
         self.lib_path = model_lib
         self.stanlib = ctypes.CDLL(self.lib_path)

--- a/python/test/test_stanmodel.py
+++ b/python/test/test_stanmodel.py
@@ -23,13 +23,19 @@ def test_constructor():
     b2 = bs.StanModel(bernoulli_so, bernoulli_data)
     np.testing.assert_allclose(bool(b2), True)
 
+    bernoulli_data_string = (
+        STAN_FOLDER / "bernoulli" / "bernoulli.data.json"
+    ).read_text()
+    b3 = bs.StanModel(bernoulli_so, bernoulli_data_string)
+    np.testing.assert_allclose(bool(b3), True)
+
     # test missing so file
     with np.testing.assert_raises(FileNotFoundError):
         bs.StanModel("nope, not going to find it")
 
     # test missing data file
     with np.testing.assert_raises(FileNotFoundError):
-        bs.StanModel(bernoulli_so, "nope, not going to find it")
+        bs.StanModel(bernoulli_so, "nope, not going to find it.json")
 
     # test data load exception
     throw_data_so = str(STAN_FOLDER / "throw_data" / "throw_data_model.so")

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -13,7 +13,9 @@ typedef int bool;
  * generator (PRNG) wrapper.  Data must be encoded in JSON as
  * indicated in the *CmdStan Reference Manual*.
  *
- * @param[in] data_file C-style path to JSON-encoded data file
+ * @param[in] data_file C-style string. This is either a
+ * path to JSON-encoded data file (must end with ".json"), or
+ * a string representation of a JSON object.
  * @param[in] seed seed for PRNG
  * @param[in] chain_id identifier for concurrent sequence of PRNG
  * draws
@@ -159,11 +161,11 @@ int bs_param_unconstrain(bs_model_rng* mr, const double* theta,
  * specification of the constrained parameters, and return a return
  * code of 0 for success and -1 for failure.  Parameter order is as
  * declared in the Stan program, with multivariate parameters given
- * in last-index-major order.  The JSON schema assumed is fully
+ * in last-index-major order. The JSON schema assumed is fully
  * defined in the *CmdStan Reference Manual*.
  *
  * @param[in] mr pointer to model and RNG structure
- * @param[in] json json-encoded constrained parameters
+ * @param[in] json JSON-encoded constrained parameters
  * @param[out] theta_unc sequence of unconstrained parameters
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code


### PR DESCRIPTION
Closes #59. The `data` argument to construct can now be either a file path (must end in `.json`) **or** a string containing the json directly