### PR TITLE
[Release] Version bumps and doc for 1.0 release

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bridgestan
 Title: BridgeStan, Accessing Stan Model Functions in R
-Version: 0.0.1
+Version: 1.0.0
 Authors@R:
     person(given="Brian", family="Ward", , "bward@flatironinstitute.org", role = c("aut", "cre"))
 License: BSD_3_clause

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -20,8 +20,18 @@ Downloading BridgeStan
 Installing BridgeStan is as simple as ensuring that the above requirements are installed and then downloading
 the source repository.
 
-Installing with ``git``
-_______________________
+Downloading a released archive
+______________________________
+
+Downloads of a complete copy of the source code and interfaces are available
+on `our GitHub releases page <https://github.com/roualdes/bridgestan/releases>`__.
+
+To use these, simply download the file associated with the version you wish to use,
+and unzip its contents into the folder you would like BridgeStan to be in.
+
+
+Installing the latest version with ``git``
+__________________________________________
 
 If you have ``git`` installed, you may download BridgeStan by navigating to the folder you'd like
 BridgeStan to be in and running

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,4 +1,4 @@
 name = "BridgeStan"
 uuid = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
 authors = ["Brian Ward <bward@flatironinstitute.org>", "Bob Carpenter <bcarpenter@flatironinstitute.org", "Edward Roualdes <eroualdes@csuchico.edu>"]
-version = "0.0.1"
+version = "1.0.0"

--- a/julia/docs/Manifest.toml
+++ b/julia/docs/Manifest.toml
@@ -15,7 +15,7 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 [[deps.BridgeStan]]
 path = ".."
 uuid = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
-version = "0.1.0"
+version = "1.0.0"
 
 [[deps.Dates]]
 deps = ["Printf"]

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bridgestan
-version = 0.0.1
+version = 1.0.0
 
 [options]
 python_requires = >=3.9

--- a/python/test/test_stanmodel.py
+++ b/python/test/test_stanmodel.py
@@ -56,6 +56,8 @@ def test_model_info():
     std_so = str(STAN_FOLDER / "stdnormal" / "stdnormal_model.so")
     b = bs.StanModel(std_so)
     assert "STAN_OPENCL" in b.model_info()
+    assert "BridgeStan version: 1." in b.model_info()
+
 
 
 def test_param_num():

--- a/src/model_rng.cpp
+++ b/src/model_rng.cpp
@@ -1,4 +1,5 @@
 #include "model_rng.hpp"
+#include "version.hpp"
 #include <stan/io/ends_with.hpp>
 #include <stan/io/json/json_data.hpp>
 #include <stan/io/array_var_context.hpp>
@@ -85,6 +86,9 @@ bs_model_rng::bs_model_rng(const char* data_file, unsigned int seed,
   name_ = strdup(model_name_c);
 
   std::stringstream info;
+  info << "BridgeStan version: " << bridgestan::MAJOR_VERSION << '.'
+       << bridgestan::MINOR_VERSION << '.' << bridgestan::PATCH_VERSION
+       << std::endl;
   info << "Stan version: " << stan::MAJOR_VERSION << '.' << stan::MINOR_VERSION
        << '.' << stan::PATCH_VERSION << std::endl;
 

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -1,0 +1,31 @@
+#ifndef BRIDGESTAN_VERSION_HPP
+#define BRIDGESTAN_VERSION_HPP
+
+#include <string>
+
+#ifndef BRIDGESTAN_STRING_EXPAND
+#define BRIDGESTAN_STRING_EXPAND(s) #s
+#endif
+
+#ifndef BRIDGESTAN_STRING
+#define BRIDGESTAN_STRING(s) BRIDGESTAN_STRING_EXPAND(s)
+#endif
+
+#define BRIDGESTAN_MAJOR 1
+#define BRIDGESTAN_MINOR 0
+#define BRIDGESTAN_PATCH 0
+
+namespace bridgestan {
+
+/** Major version number for Stan package. */
+const std::string MAJOR_VERSION = BRIDGESTAN_STRING(BRIDGESTAN_MAJOR);
+
+/** Minor version number for Stan package. */
+const std::string MINOR_VERSION = BRIDGESTAN_STRING(BRIDGESTAN_MINOR);
+
+/** Patch version for Stan package. */
+const std::string PATCH_VERSION = BRIDGESTAN_STRING(BRIDGESTAN_PATCH);
+
+}  // namespace bridgestan
+
+#endif

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -17,13 +17,13 @@
 
 namespace bridgestan {
 
-/** Major version number for Stan package. */
+/** Major version number for BridgeStan. */
 const std::string MAJOR_VERSION = BRIDGESTAN_STRING(BRIDGESTAN_MAJOR);
 
-/** Minor version number for Stan package. */
+/** Minor version number for BridgeStan. */
 const std::string MINOR_VERSION = BRIDGESTAN_STRING(BRIDGESTAN_MINOR);
 
-/** Patch version for Stan package. */
+/** Patch version for BridgeStan. */
 const std::string PATCH_VERSION = BRIDGESTAN_STRING(BRIDGESTAN_PATCH);
 
 }  // namespace bridgestan


### PR DESCRIPTION
This closes #19 and should be the last PR merged before BridgeStan 1.0.0 is released. 

A draft release is already visible (if you have write access to the repo) on the releases page https://github.com/roualdes/bridgestan/releases.

After this is merged I will add the current state of `main` as a `.tar.gz` file to that release and then we can publish it.

Changes:
- Set versions in each interface to 1.0
- Added text to the getting started page about downloading from the Releases page 
- Added a `version.hpp` based off of Stan's `version.hpp` and included the current BridgeStan version in `model_info`.