### PR TITLE
Add Julia doc to emphasize compile_model args in StanModel; re issue #64

### DIFF
--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -12,7 +12,7 @@ If seed or chain_id are supplied, these are used to initialize the RNG used by t
 
     StanModel(;stan_file, data="", seed=204, chain_id=0)
 
-Construct a StanModel instance from a `.stan` file, compiling if necessary.
+Construct a `StanModel` instance from a `.stan` file, compiling if necessary.
 
     StanModel(;stan_file, stanc_args=[], make_args=[], data="", seed=204, chain_id=0)
 
@@ -20,7 +20,7 @@ Construct a `StanModel` instance from a `.stan` file.  Compilation
 occurs if no shared object file exists for the supplied Stan file or
 if a shared object file exists and the Stan file has changed since
 last compilation.  This is equivalent to calling `compile_model` and
-then the original constructor of StanModel.
+then the original constructor of `StanModel`.
 """
 mutable struct StanModel
     lib::Ptr{Nothing}

--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -6,7 +6,7 @@ mutable struct StanModelStruct end
 
 A StanModel instance encapsulates a Stan model instantiated with data.
 
-The constructor a Stan model from the supplied library file path and data. Data
+Construct a Stan model from the supplied library file path and data. Data
 should either be a string containing a JSON object or a path to a data file ending in `.json`.
 If seed or chain_id are supplied, these are used to initialize the RNG used by the model.
 
@@ -14,7 +14,11 @@ If seed or chain_id are supplied, these are used to initialize the RNG used by t
 
 Construct a StanModel instance from a `.stan` file, compiling if necessary.
 
-This is equivalent to calling `compile_model` and then the original constructor of StanModel.
+    StanModel(;stan_file, stanc_args=[], make_args=[], data="", seed=204, chain_id=0)
+
+Construct a StanModel instance from a `.stan` file, compiling if
+necessary.  This is equivalent to calling `compile_model` and then the
+original constructor of StanModel.
 """
 mutable struct StanModel
     lib::Ptr{Nothing}

--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -7,7 +7,7 @@ mutable struct StanModelStruct end
 A StanModel instance encapsulates a Stan model instantiated with data.
 
 Construct a Stan model from the supplied library file path and data. Data
-should either be a string containing a JSON object or a path to a data file ending in `.json`.
+should either be a string containing a JSON string literal or a path to a data file ending in `.json`.
 If seed or chain_id are supplied, these are used to initialize the RNG used by the model.
 
     StanModel(;stan_file, data="", seed=204, chain_id=0)
@@ -16,9 +16,11 @@ Construct a StanModel instance from a `.stan` file, compiling if necessary.
 
     StanModel(;stan_file, stanc_args=[], make_args=[], data="", seed=204, chain_id=0)
 
-Construct a StanModel instance from a `.stan` file, compiling if
-necessary.  This is equivalent to calling `compile_model` and then the
-original constructor of StanModel.
+Construct a `StanModel` instance from a `.stan` file.  Compilation
+occurs if no shared object file exists for the supplied Stan file or
+if a shared object file exists and the Stan file has changed since
+last compilation.  This is equivalent to calling `compile_model` and
+then the original constructor of StanModel.
 """
 mutable struct StanModel
     lib::Ptr{Nothing}


### PR DESCRIPTION
Re Issue #64, duplicate some doc to emphasize that `StanModel` can accept and pass to `compile_model` the arguments to tweak compilation, `make_args`, and Stanc transpilation `stanc_args`.