### PR TITLE
change JSON object to JSON string literal for all BridgeStan owned files

### DIFF
--- a/R/R/bridgestan.R
+++ b/R/R/bridgestan.R
@@ -10,7 +10,7 @@ StanModel <- R6::R6Class("StanModel",
     #' @description
     #' Create a Stan Model instace.
     #' @param lib A path to a compiled BridgeStan Shared Object file.
-    #' @param data Either a string representation of a JSON object or a path to a data file in JSON format ending in ".json".
+    #' @param data Either a JSON string literal or a path to a data file in JSON format ending in ".json".
     #' @param rng_seed Seed for the RNG in the model object.
     #' @param chain_id Used to offset the RNG by a fixed amount.
     #' @return A new StanModel.

--- a/docs/languages/r.md
+++ b/docs/languages/r.md
@@ -70,7 +70,7 @@ _Arguments_
 
   - `lib` A path to a compiled BridgeStan Shared Object file.
 
-  - `data` Either a string representation of a JSON object or a path to a data file in JSON format ending in ".json".
+  - `data` Either a JSON string literal or a path to a data file in JSON format ending in ".json".
 
   - `rng_seed` Seed for the RNG in the model object.
 
@@ -380,5 +380,3 @@ _Returns_
 
   List containing entries `val` (the log density), `gradient`
   (the gradient), and `hessian` (the Hessian).
-
-

--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -22,7 +22,7 @@ class StanModel:
     return values.  The constructor arguments are
 
     :param model_lib: A path to a compiled shared object.
-    :param model_data: Either a string representation of a JSON object or a
+    :param model_data: Either a JSON string literal or a
          path to a data file in JSON format ending in ``.json``.
     :param seed: A pseudo random number generator seed.
     :param chain_id: A unique identifier for concurrent chains of
@@ -45,7 +45,7 @@ class StanModel:
         constructor arguments.
 
         :param model_lib: A system path to compiled shared object.
-        :param model_data: Either a string representation of a JSON object or a
+        :param model_data: Either a JSON string literal or a
             system path to a data file in JSON format ending in ``.json``.
         :param seed: A pseudo random number generator seed.
         :param chain_id: A unique identifier for concurrent chains of

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -15,7 +15,7 @@ typedef int bool;
  *
  * @param[in] data_file C-style string. This is either a
  * path to JSON-encoded data file (must end with ".json"), or
- * a string representation of a JSON object.
+ * a JSON string literal.
  * @param[in] seed seed for PRNG
  * @param[in] chain_id identifier for concurrent sequence of PRNG
  * draws


### PR DESCRIPTION
There are some occurrences of JSON object in files not directly owned by BridgeStan, so I left those out.