### PR TITLE
Add unified release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,4 +98,4 @@ jobs:
         with:
           sha: ${{ steps.commit.outputs.sha }}
           body: |
-            @JuliaRegistrator register
+            @JuliaRegistrator register subdir=julia

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,101 @@
+name: Release BridgeStan
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_version:
+        description: 'New version, for example: 1.1.0'
+        required: true
+      is_rerun:
+        type: boolean
+        description: Set to true if this version has already been 'released', e.g. to only re-run PyPI and Julia release steps
+
+jobs:
+  release:
+    name: Release BridgeStan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out github
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Set up Julia
+        uses: julia-actions/setup-julia@v1
+
+      - name: Update version numbers
+        if: ${{ !inputs.is_rerun }}
+        run: |
+          sed -i 's/Version:.*/Version: ${{ github.event.inputs.new_version }}/' R/DESCRIPTION
+          sed -i 's/version = .*/version = "${{ github.event.inputs.new_version }}"/' julia/Project.toml
+          sed -i 's/version = .*/version = ${{ github.event.inputs.new_version }}/' python/setup.cfg
+
+          sed -i 's/#define BRIDGESTAN_MAJOR .*/#define BRIDGESTAN_MAJOR '"$(echo ${{ github.event.inputs.new_version }} | cut -d. -f1)"'/' src/version.hpp
+          sed -i 's/#define BRIDGESTAN_MINOR .*/#define BRIDGESTAN_MINOR '"$(echo ${{ github.event.inputs.new_version }} | cut -d. -f2)"'/' src/version.hpp
+          sed -i 's/#define BRIDGESTAN_PATCH .*/#define BRIDGESTAN_PATCH '"$(echo ${{ github.event.inputs.new_version }} | cut -d. -f3)"'/' src/version.hpp
+
+
+      - name: Create tarball
+        run: |
+          tar --exclude-vcs -czvf bridgestan-${{ github.event.inputs.new_version }}.tar.gz --transform 's,^,bridgestan-${{ github.event.inputs.new_version }}/,' *
+
+        # Note: because of the order of operations here, the Julia package inside the tarball can never point to itself.
+      - name: Update Julia artifact
+        if: ${{ !inputs.is_rerun }}
+        run: |
+          julia ./julia/updateArtifacts.jl bridgestan-${{ github.event.inputs.new_version }}.tar.gz "v${{ github.event.inputs.new_version }}"
+
+      - name: Setup git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create commit
+        id: commit
+        run: |
+          git commit -am "Release ${{ github.event.inputs.new_version }}: updating version numbers" || true
+          git push origin main
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build Python package wheels
+        run: |
+          pip install wheel build
+          cd python/
+          python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-artifacts
+          path: |
+            python/dist/
+            bridgestan-*.tar.gz
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "bridgestan-*.tar.gz,python/dist/*"
+          tag: "v${{ github.event.inputs.new_version }}"
+          commit: main
+          omitBody: true
+          skipIfReleaseExists: true
+
+      - name: Upload PyPI wheels
+        uses: pypa/gh-action-pypi-publish@v1.6.4
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          packages_dir: python/dist/
+          skip_existing: true
+
+      - name: Create JuliaRegistration comment
+        uses: peter-evans/commit-comment@v2
+        with:
+          sha: ${{ steps.commit.outputs.sha }}
+          body: |
+            @JuliaRegistrator register

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,10 @@ jobs:
           artifacts: "bridgestan-*.tar.gz,python/dist/*"
           tag: "v${{ github.event.inputs.new_version }}"
           commit: main
-          omitBody: true
+          draft: true
+          generateReleaseNotes: true
+          allowUpdates: true
+          replacesArtifacts: true
           skipIfReleaseExists: true
 
       - name: Upload PyPI wheels

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -22,8 +22,35 @@
 ## Installation
 
 
-This assumes you have followed the [Getting Started guide](../getting-started.rst) to install BridgeStan's pre-requisites and downloaded a copy of the BridgeStan source code.
-Note that the Julia interface has the ability to install the BridgeStan source if the ``BRIDGESTAN`` environment variable is not set.
+<a id='From-JuliaRegistries'></a>
+
+<a id='From-JuliaRegistries-1'></a>
+
+### From JuliaRegistries
+
+
+BridgeStan is registered on JuliaRegistries each release.
+
+
+```julia
+] add BridgeStan
+```
+
+
+The first time you need it, the BridgeStan source code will be downloaded as an [Artifact](https://pkgdocs.julialang.org/v1/artifacts/). If you prefer to use a source distribution of BridgeStan, consult the following section.
+
+
+Note that the system pre-requisites from the [Getting Started Guide](../getting-started.rst) are still required and will not be automatically installed by this method.
+
+
+<a id='From-Source'></a>
+
+<a id='From-Source-1'></a>
+
+### From Source
+
+
+This section assumes you have followed the [Getting Started guide](../getting-started.rst) to install BridgeStan's pre-requisites and downloaded a copy of the BridgeStan source code.
 
 
 To install the Julia interface, you can either install it directly from Github by running the following inside a Julia REPL
@@ -94,18 +121,22 @@ StanModel(lib, datafile="", seed=204, chain_id=0)
 
 A StanModel instance encapsulates a Stan model instantiated with data.
 
-The constructor a Stan model from the supplied library file path and data. Data should either be a string containing a JSON object or a path to a data file ending in `.json`. If seed or chain_id are supplied, these are used to initialize the RNG used by the model.
+Construct a Stan model from the supplied library file path and data. Data should either be a string containing a JSON string literal or a path to a data file ending in `.json`. If seed or chain_id are supplied, these are used to initialize the RNG used by the model.
 
 ```
 StanModel(;stan_file, data="", seed=204, chain_id=0)
 ```
 
-Construct a StanModel instance from a `.stan` file, compiling if necessary.
+Construct a `StanModel` instance from a `.stan` file, compiling if necessary.
 
-This is equivalent to calling `compile_model` and then the original constructor of StanModel.
+```
+StanModel(;stan_file, stanc_args=[], make_args=[], data="", seed=204, chain_id=0)
+```
+
+Construct a `StanModel` instance from a `.stan` file.  Compilation occurs if no shared object file exists for the supplied Stan file or if a shared object file exists and the Stan file has changed since last compilation.  This is equivalent to calling `compile_model` and then the original constructor of `StanModel`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L4-L18' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L13-L33' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density' href='#BridgeStan.log_density'>#</a>
 **`BridgeStan.log_density`** &mdash; *Function*.
@@ -121,7 +152,7 @@ Return the log density of the specified unconstrained parameters.
 This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L359-L366' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L374-L381' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient' href='#BridgeStan.log_density_gradient'>#</a>
 **`BridgeStan.log_density_gradient`** &mdash; *Function*.
@@ -139,7 +170,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L431-L443' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L446-L458' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian' href='#BridgeStan.log_density_hessian'>#</a>
 **`BridgeStan.log_density_hessian`** &mdash; *Function*.
@@ -157,7 +188,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient and Hessian output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L517-L528' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L532-L543' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain' href='#BridgeStan.param_constrain'>#</a>
 **`BridgeStan.param_constrain`** &mdash; *Function*.
@@ -175,7 +206,7 @@ This allocates new memory for the output each call. See `param_constrain!` for a
 This is the inverse of `param_unconstrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L230-L242' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L245-L257' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain' href='#BridgeStan.param_unconstrain'>#</a>
 **`BridgeStan.param_unconstrain`** &mdash; *Function*.
@@ -195,7 +226,7 @@ This allocates new memory for the output each call. See `param_unconstrain!` for
 This is the inverse of `param_constrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L290-L303' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L305-L318' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json' href='#BridgeStan.param_unconstrain_json'>#</a>
 **`BridgeStan.param_unconstrain_json`** &mdash; *Function*.
@@ -213,7 +244,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 This allocates new memory for the output each call. See `param_unconstrain_json!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L343-L353' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L358-L368' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.name' href='#BridgeStan.name'>#</a>
 **`BridgeStan.name`** &mdash; *Function*.
@@ -227,7 +258,7 @@ name(sm)
 Return the name of the model `sm`
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L74-L78' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L89-L93' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.model_info' href='#BridgeStan.model_info'>#</a>
 **`BridgeStan.model_info`** &mdash; *Function*.
@@ -243,7 +274,7 @@ Return information about the model `sm`.
 This includes the Stan version and important compiler flags.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L89-L96' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L104-L111' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_num' href='#BridgeStan.param_num'>#</a>
 **`BridgeStan.param_num`** &mdash; *Function*.
@@ -259,7 +290,7 @@ Return the number of (constrained) parameters in the model.
 This is the total of all the sizes of items declared in the `parameters` block of the model. If `include_tp` or `include_gq` are true, items declared in the `transformed parameters` and `generate quantities` blocks are included, respectively.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L107-L116' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L122-L131' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_num' href='#BridgeStan.param_unc_num'>#</a>
 **`BridgeStan.param_unc_num`** &mdash; *Function*.
@@ -275,7 +306,7 @@ Return the number of unconstrained parameters in the model.
 This function is mainly different from `param_num` when variables are declared with constraints. For example, `simplex[5]` has a constrained size of 5, but an unconstrained size of 4.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L129-L137' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L144-L152' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_names' href='#BridgeStan.param_names'>#</a>
 **`BridgeStan.param_names`** &mdash; *Function*.
@@ -293,7 +324,7 @@ For containers, indexes are separated by periods (.).
 For example, the scalar `a` has indexed name `"a"`, the vector entry `a[1]` has indexed name `"a.1"` and the matrix entry `a[2, 3]` has indexed names `"a.2.3"`. Parameter order of the output is column major and more generally last-index major for containers.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L147-L158' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L162-L173' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_names' href='#BridgeStan.param_unc_names'>#</a>
 **`BridgeStan.param_unc_names`** &mdash; *Function*.
@@ -309,7 +340,7 @@ Return the indexed names of the unconstrained parameters.
 For example, a scalar unconstrained parameter `b` has indexed name `b` and a vector entry `b[3]` has indexed name `b.3`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L171-L178' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L186-L193' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient!' href='#BridgeStan.log_density_gradient!'>#</a>
 **`BridgeStan.log_density_gradient!`** &mdash; *Function*.
@@ -327,7 +358,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out`, and a reference is returned. See `log_density_gradient` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L386-L396' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L401-L411' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian!' href='#BridgeStan.log_density_hessian!'>#</a>
 **`BridgeStan.log_density_hessian!`** &mdash; *Function*.
@@ -345,7 +376,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out_grad` and the Hessian is stored in `out_hess` and references are returned. See `log_density_hessian` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L454-L465' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L469-L480' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain!' href='#BridgeStan.param_constrain!'>#</a>
 **`BridgeStan.param_constrain!`** &mdash; *Function*.
@@ -363,7 +394,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_unconstrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L189-L200' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L204-L215' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain!' href='#BridgeStan.param_unconstrain!'>#</a>
 **`BridgeStan.param_unconstrain!`** &mdash; *Function*.
@@ -383,7 +414,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_constrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L253-L265' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L268-L280' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json!' href='#BridgeStan.param_unconstrain_json!'>#</a>
 **`BridgeStan.param_unconstrain_json!`** &mdash; *Function*.
@@ -401,7 +432,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 The result is stored in the vector `out`, and a reference is returned. See `param_unconstrain_json` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L309-L318' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L324-L333' class='documenter-source'>source</a><br>
 
 
 <a id='Compilation-utilities'></a>
@@ -424,7 +455,23 @@ Run BridgeStan’s Makefile on a `.stan` file, creating the `.so` used by StanMo
 This function assumes that the path to BridgeStan is valid. This can be set with `set_bridgestan_path!()`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L42-L55' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L50-L63' class='documenter-source'>source</a><br>
+
+<a id='BridgeStan.get_bridgestan_path' href='#BridgeStan.get_bridgestan_path'>#</a>
+**`BridgeStan.get_bridgestan_path`** &mdash; *Function*.
+
+
+
+```julia
+get_bridgestan_path() -> String
+```
+
+Return the path the the BridgeStan directory.
+
+If the environment variable `BRIDGESTAN` is set, this will be returned. Otherwise, this function downloads an artifact containing the BridgeStan repository and returns the path to the extracted directory.
+
+
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L6-L14' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.set_bridgestan_path!' href='#BridgeStan.set_bridgestan_path!'>#</a>
 **`BridgeStan.set_bridgestan_path!`** &mdash; *Function*.
@@ -440,5 +487,5 @@ Set the path BridgeStan.
 By default this is set to the value of the environment variable `BRIDGESTAN`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L28-L35' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L36-L43' class='documenter-source'>source</a><br>
 

--- a/docs/languages/python.rst
+++ b/docs/languages/python.rst
@@ -8,6 +8,22 @@ Python Interface
 Installation
 ------------
 
+From PyPI
+_________
+
+For convience, BridgeStan is uploaded to the Python Package Index each release.
+
+.. code-block:: shell
+
+    pip install bridgestan
+
+Currently, this package does **not** come with a copy of the BridgeStan C++
+source code, so you will need to follow the instructions from the
+:doc:`Getting Started guide <../getting-started>` to download this, and use
+:func:`set_bridgestan_path` or the ``$BRIDGESTAN`` environment variable.
+
+From Source
+___________
 This assumes you have followed the :doc:`Getting Started guide <../getting-started>` to install
 BridgeStan's pre-requisites and downloaded a copy of the BridgeStan source code.
 
@@ -21,7 +37,7 @@ Or, since you have already downloaded the repository, you can run
 
 .. code-block:: shell
 
-    pip install python/
+    pip install -e python/
 
 from the BridgeStan folder.
 

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,6 +1,10 @@
 name = "BridgeStan"
 uuid = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
-authors = ["Brian Ward <bward@flatironinstitute.org>", "Bob Carpenter <bcarpenter@flatironinstitute.org", "Edward Roualdes <eroualdes@csuchico.edu>"]
+authors = [
+    "Brian Ward <bward@flatironinstitute.org>",
+    "Bob Carpenter <bcarpenter@flatironinstitute.org",
+    "Edward Roualdes <eroualdes@csuchico.edu>",
+]
 version = "1.0.0"
 
 [deps]

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,10 +1,6 @@
 name = "BridgeStan"
 uuid = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
-authors = [
-    "Brian Ward <bward@flatironinstitute.org>",
-    "Bob Carpenter <bcarpenter@flatironinstitute.org",
-    "Edward Roualdes <eroualdes@csuchico.edu>",
-]
+authors = ["Brian Ward <bward@flatironinstitute.org>", "Bob Carpenter <bcarpenter@flatironinstitute.org", "Edward Roualdes <eroualdes@csuchico.edu>"]
 version = "1.0.0"
 
 [deps]

--- a/julia/docs/src/julia.md
+++ b/julia/docs/src/julia.md
@@ -11,7 +11,24 @@
 
 ## Installation
 
-This assumes you have followed the [Getting Started guide](../getting-started.rst)
+### From JuliaRegistries
+
+BridgeStan is registered on JuliaRegistries each release.
+
+
+```julia
+] add BridgeStan
+```
+
+The first time you need it, the BridgeStan source code will be downloaded
+as an [Artifact](https://pkgdocs.julialang.org/v1/artifacts/). If you
+prefer to use a source distribution of BridgeStan, consult the following section.
+
+Note that the system pre-requisites from the [Getting Started Guide](../getting-started.rst)
+are still required and will not be automatically installed by this method.
+
+### From Source
+This section assumes you have followed the [Getting Started guide](../getting-started.rst)
 to install BridgeStan's pre-requisites and downloaded a copy of the BridgeStan source code.
 
 To install the Julia interface, you can either install it directly from Github by running

--- a/julia/test/compile_tests.jl
+++ b/julia/test/compile_tests.jl
@@ -36,9 +36,3 @@ end
     @test_throws ErrorException BridgeStan.set_bridgestan_path!("dummy")
     @test_throws ErrorException BridgeStan.set_bridgestan_path!(models)
 end
-
-@testset "download artifact" begin
-    withenv("BRIDGESTAN" => nothing) do
-        BridgeStan.validate_stan_dir(BridgeStan.get_bridgestan_path())
-    end
-end

--- a/julia/test/model_tests.jl
+++ b/julia/test/model_tests.jl
@@ -1,5 +1,4 @@
 using BridgeStan
-using BridgeStan: @const
 using Test
 using Printf
 
@@ -12,28 +11,6 @@ function load_test_model(name::String, with_data = true)
         data = ""
     end
     return BridgeStan.StanModel(lib, data)
-end
-
-mutable struct Foo
-    x
-    @const y
-end
-
-@testset "@const utility" begin
-    a = Foo(1, 2)
-    @test a.x == 1
-    @test a.y == 2
-    a.x = 3
-    @test a.x == 3
-    @test a.y == 2
-    if VERSION ≥ v"1.8"
-        # y is const
-        @test_throws ErrorException a.y = 4
-    else
-        # y is mutable
-        a.y = 4
-        @test a.y == 4
-    end
 end
 
 @testset "constructor" begin

--- a/julia/test/runtests.jl
+++ b/julia/test/runtests.jl
@@ -1,2 +1,3 @@
 include("compile_tests.jl")
 include("model_tests.jl")
+include("util_tests.jl")

--- a/julia/test/util_tests.jl
+++ b/julia/test/util_tests.jl
@@ -1,0 +1,33 @@
+using BridgeStan
+using BridgeStan: @const
+using Test
+
+mutable struct Foo
+    x::Any
+    @const y
+end
+
+@testset "@const utility" begin
+    a = Foo(1, 2)
+    @test a.x == 1
+    @test a.y == 2
+    a.x = 3
+    @test a.x == 3
+    @test a.y == 2
+    if VERSION ≥ v"1.8"
+        # y is const
+        @test_throws ErrorException a.y = 4
+    else
+        # y is mutable
+        a.y = 4
+        @test a.y == 4
+    end
+end
+
+
+
+@testset "download artifact" begin
+    withenv("BRIDGESTAN" => nothing) do
+        BridgeStan.validate_stan_dir(BridgeStan.get_bridgestan_path())
+    end
+end

--- a/julia/updateArtifacts.jl
+++ b/julia/updateArtifacts.jl
@@ -1,0 +1,26 @@
+import Pkg;
+Pkg.add("Inflate");
+using Tar, Inflate, SHA, TOML
+
+filename = ARGS[1]
+version = ARGS[2]
+
+data = Dict(
+    "bridgestan" => Dict(
+        "git-tree-sha1" => Tar.tree_hash(IOBuffer(inflate_gzip(filename))),
+        "lazy" => true,
+        "download" => Dict(
+            "sha256" => bytes2hex(open(sha256, filename)),
+            "url" => string(
+                "https://github.com/roualdes/bridgestan/releases/download/",
+                version,
+                "/",
+                filename,
+            ),
+        ),
+    ),
+)
+
+open("julia/Artifacts.toml", "w") do io
+    TOML.print(io, data)
+end

--- a/python/README.md
+++ b/python/README.md
@@ -4,13 +4,14 @@
 
 ## Installation
 
-**From Github**:
+**From PyPI (Requires separate download of C++ source code)**:
 ```shell
-pip install "git+https://github.com/roualdes/bridgestan.git#egg=bridgestan&subdirectory=python"
+pip install bridgestan
 ```
 
 **From the downloaded repository**:
+Assuming you have already cloned https://github.com/roualdes/bridgestan
 ```shell
 cd python/ # this directory
-pip install .
+pip install -e .
 ```

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,5 +1,10 @@
 [metadata]
 name = bridgestan
+author = Brian Ward, Edward Roualdes, Bob Carpenter
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = BSD 3-Clause License
+url=https://github.com/roualdes/bridgestan
 version = 1.0.0
 
 [options]


### PR DESCRIPTION
This builds on @sethaxen's work in #70 to create a unified release action for the repo. It also updates a few documentation pages in anticipation of the release.

The steps the Action takes are roughly:

1. Replace the version numbers in all interfaces with the new version
2. Build the `.tar.gz` file we attach to a release
3. Update the Julia `Artifacts.toml` file
4. Push a commit to the repo with the above changes
5. Create a tag and release
6. Push to PyPI (@roualdes this will require us adding a Secret to the repository for a PyPI token once)
7. Comment on the commit from `4` with a `@JuliaRegistrator register`  (@roualdes this will require following the pre-registration instructions here https://github.com/JuliaRegistries/Registrator.jl once)

If any step up to and including 5 fails, you can re-run the script without any problem. If any step _after_ 5 fails, you need to check a box on the Workflow page while running which will skip re-creating the release, and will just upload to PyPI/JuliaRegistries

After the automated release we can manually edit the releases page to include the change log.

After this is merged I suggest we more or less immediately run it to release `1.0.1` which will start the Julia Registration process. We can also discuss if we want to eventually make the Python interface able to download the C++ source, like the Julia interface now can, but I decided to leave that for later.