### PR TITLE
example.R: add missing instructions

### DIFF
--- a/R/example.R
+++ b/R/example.R
@@ -1,3 +1,7 @@
+# Before running this: 
+#  - In the terminal, run `make test_models/bernoulli/bernoulli_model.so` from inside the bridgestan folder
+#  - In R, make sure you are in the directory bridgestan/R 
+
 library(bridgestan)
 
 model <- StanModel$new("../test_models/bernoulli/bernoulli_model.so", "../test_models/bernoulli/bernoulli.data.json", 1234, 0)


### PR DESCRIPTION
The instructions at https://roualdes.github.io/bridgestan/languages/r.html#example-program are incomplete. This adds the missing instructions necessary to run the example without errors. I added them as comments in example.R but it could also just go in the text in the markdown file. 