### PR TITLE
Make sure -fPIC is set globally so Sundials can link

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
 
 jobs:
   build_test_models:

--- a/c-example/Makefile
+++ b/c-example/Makefile
@@ -3,12 +3,13 @@ BS_ROOT=..
 include ../Makefile
 
 MODEL?=full
+CC ?= gcc
 
 ../test_models/$(MODEL)/lib$(MODEL)_model.so: ../test_models/$(MODEL)/$(MODEL)_model.so
 	cp ../test_models/$(MODEL)/$(MODEL)_model.so ../test_models/$(MODEL)/lib$(MODEL)_model.so
 
 example$(EXE): example.c ../test_models/$(MODEL)/lib$(MODEL)_model.so
-	gcc -c -I ../src example.c -o example.o
+	$(CC) -c -I ../src example.c -o example.o
 	$(LINK.c) -o example$(EXE) example.o -Wl,-rpath ../test_models/$(MODEL) -L ../test_models/$(MODEL) -l$(MODEL)_model
 	$(RM) example.o
 
@@ -17,13 +18,13 @@ example$(EXE): example.c ../test_models/$(MODEL)/lib$(MODEL)_model.so
 # this is very similar to the core Make rule in BridgeStan, just with AR instead of LINK
 %_model.a: %.hpp $(BRIDGE_O) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
 	@echo '--- Compiling C++ code ---'
-	$(COMPILE.cpp) $(CXXFLAGS_PROGRAM) -fPIC $(CXXFLAGS_THREADS) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
+	$(COMPILE.cpp) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
 	@echo '--- Creating static library ---'
 	$(AR) -rcs $(patsubst %.hpp, %_model.a, $(subst \,/,$<)) $(subst \,/,$*.o) $(BRIDGE_O)
 	$(RM) $(subst  \,/,$*).o
 
 
 example_static$(EXE):  example.c ../test_models/$(MODEL)/$(MODEL)_model.a
-	gcc -c -I ../src example.c -o example.o
+	$(CC) -c -I ../src example.c -o example.o
 	$(LINK.cpp) -o example_static$(EXE) example.o ../test_models/$(MODEL)/$(MODEL)_model.a $(LDLIBS) $(LIBSUNDIALS) $(MPI_TARGETS) $(TBB_TARGETS)
 	$(RM) example.o

--- a/test_models/ode/ode.stan
+++ b/test_models/ode/ode.stan
@@ -1,0 +1,27 @@
+// example model from https://mc-stan.org/docs/stan-users-guide/measurement-error-models.html
+functions {
+  vector sho(real t, vector y, real theta) {
+    vector[2] dydt;
+    dydt[1] = y[2];
+    dydt[2] = -y[1] - theta * y[2];
+    return dydt;
+  }
+}
+data {
+  int<lower=1> T;
+  vector[2] y0;
+  real t0;
+  array[T] real ts;
+  real theta;
+}
+model {
+
+}
+generated quantities {
+  array[T] vector[2] y_sim = ode_rk45(sho, y0, t0, ts, theta);
+  // add measurement error
+  for (t in 1 : T) {
+    y_sim[t, 1] += normal_rng(0, 0.1);
+    y_sim[t, 2] += normal_rng(0, 0.1);
+  }
+}


### PR DESCRIPTION
Reported by @modichirag, models which use ODE integrators from Sundials currently fail during the link step. This is because the static libraries in the Math library were not built with `-fPIC`.

This PR:
1. Globally sets -fPIC in CXXFLAGS
2. Cleans up the makefile a bit to remove unnecessary variables
3. Adds a test model from the Stan User's Guide which will be built in CI