### PR TITLE
Fix: Const correctness in C api

### DIFF
--- a/src/bridgestan.cpp
+++ b/src/bridgestan.cpp
@@ -2,7 +2,7 @@
 #include "model_rng.cpp"
 #include "bridgestanR.cpp"
 
-bs_model_rng* bs_construct(char* data_file, unsigned int seed,
+bs_model_rng* bs_construct(const char* data_file, unsigned int seed,
                            unsigned int chain_id) {
   try {
     return new bs_model_rng(data_file, seed, chain_id);
@@ -28,23 +28,23 @@ int bs_destruct(bs_model_rng* mr) {
   return -1;
 }
 
-const char* bs_name(bs_model_rng* mr) { return mr->name(); }
+const char* bs_name(const bs_model_rng* mr) { return mr->name(); }
 
-const char* bs_model_info(bs_model_rng* mr) { return mr->model_info(); }
+const char* bs_model_info(const bs_model_rng* mr) { return mr->model_info(); }
 
-const char* bs_param_names(bs_model_rng* mr, bool include_tp, bool include_gq) {
+const char* bs_param_names(const bs_model_rng* mr, bool include_tp, bool include_gq) {
   return mr->param_names(include_tp, include_gq);
 }
 
-const char* bs_param_unc_names(bs_model_rng* mr) {
+const char* bs_param_unc_names(const bs_model_rng* mr) {
   return mr->param_unc_names();
 }
 
-int bs_param_num(bs_model_rng* mr, bool include_tp, bool include_gq) {
+int bs_param_num(const bs_model_rng* mr, bool include_tp, bool include_gq) {
   return mr->param_num(include_tp, include_gq);
 }
 
-int bs_param_unc_num(bs_model_rng* mr) { return mr->param_unc_num(); }
+int bs_param_unc_num(const bs_model_rng* mr) { return mr->param_unc_num(); }
 
 int bs_param_constrain(bs_model_rng* mr, bool include_tp, bool include_gq,
                        const double* theta_unc, double* theta) {
@@ -59,7 +59,7 @@ int bs_param_constrain(bs_model_rng* mr, bool include_tp, bool include_gq,
   return 1;
 }
 
-int bs_param_unconstrain(bs_model_rng* mr, const double* theta,
+int bs_param_unconstrain(const bs_model_rng* mr, const double* theta,
                          double* theta_unc) {
   try {
     mr->param_unconstrain(theta, theta_unc);
@@ -72,7 +72,7 @@ int bs_param_unconstrain(bs_model_rng* mr, const double* theta,
   return -1;
 }
 
-int bs_param_unconstrain_json(bs_model_rng* mr, const char* json,
+int bs_param_unconstrain_json(const bs_model_rng* mr, const char* json,
                               double* theta_unc) {
   try {
     mr->param_unconstrain_json(json, theta_unc);
@@ -85,7 +85,7 @@ int bs_param_unconstrain_json(bs_model_rng* mr, const char* json,
   return -1;
 }
 
-int bs_log_density(bs_model_rng* mr, bool propto, bool jacobian,
+int bs_log_density(const bs_model_rng* mr, bool propto, bool jacobian,
                    const double* theta_unc, double* val) {
   try {
     mr->log_density(propto, jacobian, theta_unc, val);
@@ -98,7 +98,7 @@ int bs_log_density(bs_model_rng* mr, bool propto, bool jacobian,
   return -1;
 }
 
-int bs_log_density_gradient(bs_model_rng* mr, bool propto, bool jacobian,
+int bs_log_density_gradient(const bs_model_rng* mr, bool propto, bool jacobian,
                             const double* theta_unc, double* val,
                             double* grad) {
   try {
@@ -113,7 +113,7 @@ int bs_log_density_gradient(bs_model_rng* mr, bool propto, bool jacobian,
   return -1;
 }
 
-int bs_log_density_hessian(bs_model_rng* mr, bool propto, bool jacobian,
+int bs_log_density_hessian(const bs_model_rng* mr, bool propto, bool jacobian,
                            const double* theta_unc, double* val, double* grad,
                            double* hessian) {
   try {

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -22,7 +22,7 @@ typedef int bool;
  * @return pointer to constructed model or `nullptr` if construction
  * fails
  */
-bs_model_rng* bs_construct(char* data_file, unsigned int seed,
+bs_model_rng* bs_construct(const char* data_file, unsigned int seed,
                            unsigned int chain_id);
 
 /**
@@ -44,7 +44,7 @@ int bs_destruct(bs_model_rng* mr);
  * @param[in] mr pointer to model and RNG structure
  * @return name of model
  */
-const char* bs_name(bs_model_rng* mr);
+const char* bs_name(const bs_model_rng* mr);
 
 /**
  * Return information about the compiled model as a C-style string.
@@ -56,7 +56,7 @@ const char* bs_name(bs_model_rng* mr);
  * @return Information about the model including Stan version, Stan defines, and
  * compiler flags.
  */
-const char* bs_model_info(bs_model_rng* mr);
+const char* bs_model_info(const bs_model_rng* mr);
 
 /**
  * Return a comma-separated sequence of indexed parameter names,
@@ -77,7 +77,8 @@ const char* bs_model_info(bs_model_rng* mr);
  * @param[in] include_gq `true` to include generated quantities
  * @return CSV-separated, indexed, parameter names
  */
-const char* bs_param_names(bs_model_rng* mr, bool include_tp, bool include_gq);
+const char* bs_param_names(const bs_model_rng* mr, bool include_tp,
+                           bool include_gq);
 
 /**
  * Return a comma-separated sequence of unconstrained parameters.
@@ -96,7 +97,7 @@ const char* bs_param_names(bs_model_rng* mr, bool include_tp, bool include_gq);
  * @param[in] mr pointer to model and RNG structure
  * @return CSV-separated, indexed, unconstrained parameter names
  */
-const char* bs_param_unc_names(bs_model_rng* mr);
+const char* bs_param_unc_names(const bs_model_rng* mr);
 
 /**
  * Return the number of scalar parameters, optionally including the
@@ -108,7 +109,7 @@ const char* bs_param_unc_names(bs_model_rng* mr);
  * @param[in] include_gq `true` to include generated quantities
  * @return number of parameters
  */
-int bs_param_num(bs_model_rng* mr, bool include_tp, bool include_gq);
+int bs_param_num(const bs_model_rng* mr, bool include_tp, bool include_gq);
 
 /**
  * Return the number of unconstrained parameters.  The number of
@@ -119,7 +120,7 @@ int bs_param_num(bs_model_rng* mr, bool include_tp, bool include_gq);
  * @param[in] mr pointer to model and RNG structure
  * @return number of unconstrained parameters
  */
-int bs_param_unc_num(bs_model_rng* mr);
+int bs_param_unc_num(const bs_model_rng* mr);
 
 /**
  * Set the sequence of constrained parameters based on the specified
@@ -153,7 +154,7 @@ int bs_param_constrain(bs_model_rng* mr, bool include_tp, bool include_gq,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_param_unconstrain(bs_model_rng* mr, const double* theta,
+int bs_param_unconstrain(const bs_model_rng* mr, const double* theta,
                          double* theta_unc);
 
 /**
@@ -170,7 +171,7 @@ int bs_param_unconstrain(bs_model_rng* mr, const double* theta,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_param_unconstrain_json(bs_model_rng* mr, const char* json,
+int bs_param_unconstrain_json(const bs_model_rng* mr, const char* json,
                               double* theta_unc);
 
 /**
@@ -183,13 +184,13 @@ int bs_param_unconstrain_json(bs_model_rng* mr, const char* json,
  * @param[in] mr pointer to model and RNG structure
  * @param[in] propto `true` to discard constant terms
  * @param[in] jacobian `true` to include change-of-variables terms
- * @param[in] theta unconstrained parameters
+ * @param[in] theta_unc unconstrained parameters
  * @param[out] lp log density to be set
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_log_density(bs_model_rng* mr, bool propto, bool jacobian,
-                   const double* theta, double* lp);
+int bs_log_density(const bs_model_rng* mr, bool propto, bool jacobian,
+                   const double* theta_unc, double* lp);
 
 /**
  * Set the log density and gradient of the specified parameters,
@@ -204,14 +205,14 @@ int bs_log_density(bs_model_rng* mr, bool propto, bool jacobian,
  * @param[in] mr pointer to model and RNG structure
  * @param[in] propto `true` to discard constant terms
  * @param[in] jacobian `true` to include change-of-variables terms
- * @param[in] theta unconstrained parameters
+ * @param[in] theta_unc unconstrained parameters
  * @param[out] val log density to be set
  * @param[out] grad gradient to set
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_log_density_gradient(bs_model_rng* mr, bool propto, bool jacobian,
-                            const double* theta, double* val, double* grad);
+int bs_log_density_gradient(const bs_model_rng* mr, bool propto, bool jacobian,
+                            const double* theta_unc, double* val, double* grad);
 
 /**
  * Set the log density, gradient, and Hessian of the specified parameters,
@@ -228,15 +229,15 @@ int bs_log_density_gradient(bs_model_rng* mr, bool propto, bool jacobian,
  * @param[in] mr pointer to model and RNG structure
  * @param[in] propto `true` to discard constant terms
  * @param[in] jacobian `true` to include change-of-variables terms
- * @param[in] theta unconstrained parameters
+ * @param[in] theta_unc unconstrained parameters
  * @param[out] val log density to be set
  * @param[out] grad gradient to set
  * @param[out] hessian hessian to set
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_log_density_hessian(bs_model_rng* mr, bool propto, bool jacobian,
-                           const double* theta, double* val, double* grad,
+int bs_log_density_hessian(const bs_model_rng* mr, bool propto, bool jacobian,
+                           const double* theta_unc, double* val, double* grad,
                            double* hessian);
 
 #ifdef __cplusplus

--- a/src/model_rng.cpp
+++ b/src/model_rng.cpp
@@ -168,11 +168,11 @@ bs_model_rng::~bs_model_rng() {
   free(param_tp_gq_names_);
 }
 
-const char* bs_model_rng::name() { return name_; }
+const char* bs_model_rng::name() const { return name_; }
 
-const char* bs_model_rng::model_info() { return model_info_; }
+const char* bs_model_rng::model_info() const { return model_info_; }
 
-const char* bs_model_rng::param_names(bool include_tp, bool include_gq) {
+const char* bs_model_rng::param_names(bool include_tp, bool include_gq) const {
   if (include_tp && include_gq)
     return param_tp_gq_names_;
   if (include_tp)
@@ -182,11 +182,11 @@ const char* bs_model_rng::param_names(bool include_tp, bool include_gq) {
   return param_names_;
 }
 
-const char* bs_model_rng::param_unc_names() { return param_unc_names_; }
+const char* bs_model_rng::param_unc_names() const { return param_unc_names_; }
 
-int bs_model_rng::param_unc_num() { return param_unc_num_; }
+int bs_model_rng::param_unc_num() const { return param_unc_num_; }
 
-int bs_model_rng::param_num(bool include_tp, bool include_gq) {
+int bs_model_rng::param_num(bool include_tp, bool include_gq) const {
   if (include_tp && include_gq)
     return param_tp_gq_num_;
   if (include_tp)
@@ -196,7 +196,8 @@ int bs_model_rng::param_num(bool include_tp, bool include_gq) {
   return param_num_;
 }
 
-void bs_model_rng::param_unconstrain(const double* theta, double* theta_unc) {
+void bs_model_rng::param_unconstrain(const double* theta,
+                                     double* theta_unc) const {
   using std::set;
   using std::string;
   using std::vector;
@@ -229,7 +230,8 @@ void bs_model_rng::param_unconstrain(const double* theta, double* theta_unc) {
   Eigen::VectorXd::Map(theta_unc, unc_params.size()) = unc_params;
 }
 
-void bs_model_rng::param_unconstrain_json(const char* json, double* theta_unc) {
+void bs_model_rng::param_unconstrain_json(const char* json,
+                                          double* theta_unc) const {
   std::stringstream in(json);
   stan::json::json_data inits_context(in);
   Eigen::VectorXd params_unc;
@@ -247,7 +249,7 @@ void bs_model_rng::param_constrain(bool include_tp, bool include_gq,
   Eigen::VectorXd::Map(theta, params.size()) = params;
 }
 
-auto bs_model_rng::make_model_lambda(bool propto, bool jacobian) {
+auto bs_model_rng::make_model_lambda(bool propto, bool jacobian) const {
   return [model = this->model_, propto, jacobian](auto& x) {
     // log_prob() requires non-const but doesn't modify its argument
     auto& params
@@ -270,7 +272,7 @@ auto bs_model_rng::make_model_lambda(bool propto, bool jacobian) {
 }
 
 void bs_model_rng::log_density(bool propto, bool jacobian,
-                               const double* theta_unc, double* val) {
+                               const double* theta_unc, double* val) const {
   int N = param_unc_num_;
   if (propto) {
     Eigen::Map<const Eigen::VectorXd> params_unc(theta_unc, N);
@@ -292,7 +294,7 @@ void bs_model_rng::log_density(bool propto, bool jacobian,
 
 void bs_model_rng::log_density_gradient(bool propto, bool jacobian,
                                         const double* theta_unc, double* val,
-                                        double* grad) {
+                                        double* grad) const {
 #ifdef STAN_THREADS
   static thread_local stan::math::ChainableStack thread_instance;
 #endif
@@ -304,7 +306,7 @@ void bs_model_rng::log_density_gradient(bool propto, bool jacobian,
 
 void bs_model_rng::log_density_hessian(bool propto, bool jacobian,
                                        const double* theta_unc, double* val,
-                                       double* grad, double* hessian) {
+                                       double* grad, double* hessian) const {
 #ifdef STAN_THREADS
   static thread_local stan::math::ChainableStack thread_instance;
 #endif

--- a/src/model_rng.hpp
+++ b/src/model_rng.hpp
@@ -36,7 +36,7 @@ class bs_model_rng {
    *
    * @return name of model
    */
-  const char* name();
+  const char* name() const;
 
   /**
    *  Return information about the compiled model. This class manages the
@@ -44,7 +44,7 @@ class bs_model_rng {
    *
    * @return name of model
    */
-  const char* model_info();
+  const char* model_info() const;
 
   /**
    * Return the parameter names as a comma-separated list.  Indexes
@@ -55,7 +55,7 @@ class bs_model_rng {
    * @param[in] include_gq `true` to include generated quantities
    * @return comma-separated parameter names with indexes
    */
-  const char* param_names(bool include_tp, bool include_gq);
+  const char* param_names(bool include_tp, bool include_gq) const;
 
   /**
    * Return the unconstrained parameter names as a comma-separated
@@ -65,14 +65,14 @@ class bs_model_rng {
    * @return comma-separated unconstrained parameter names with
    * indexes
    */
-  const char* param_unc_names();
+  const char* param_unc_names() const;
 
   /**
    * Return the number of unconstrianed parameters.
    *
    * @return number of unconstrained parameters
    */
-  int param_unc_num();
+  int param_unc_num() const;
 
   /**
    * Return the number of parameters, optionally including
@@ -82,7 +82,7 @@ class bs_model_rng {
    * @param[in] include_gq `true` to include generated quantities
    * @return number of parameters
    */
-  int param_num(bool include_tp, bool include_gq);
+  int param_num(bool include_tp, bool include_gq) const;
 
   /**
    * Unconstrain the specified parameters and write into the
@@ -91,7 +91,7 @@ class bs_model_rng {
    * @param[in] theta parameters to unconstrain
    * @param[in,out] theta_unc unconstrained parameters
    */
-  void param_unconstrain(const double* theta, double* theta_unc);
+  void param_unconstrain(const double* theta, double* theta_unc) const;
 
   /**
    * Unconstrain the parameters specified as a JSON string and write
@@ -101,7 +101,7 @@ class bs_model_rng {
    * @param[in] json JSON string representing parameters
    * @param[in,out] theta_unc unconstrained parameters generated
    */
-  void param_unconstrain_json(const char* json, double* theta_unc);
+  void param_unconstrain_json(const char* json, double* theta_unc) const;
 
   /**
    * Constrain the specified unconstrained parameters into the
@@ -129,7 +129,7 @@ class bs_model_rng {
    * @param[in,out] val log density produced
    */
   void log_density(bool propto, bool jacobian, const double* theta_unc,
-                   double* val);
+                   double* val) const;
 
   /**
    * Calculate the log density and gradient for the specified
@@ -146,7 +146,7 @@ class bs_model_rng {
    * @param[in,out] grad gradient produced
    */
   void log_density_gradient(bool propto, bool jacobian, const double* theta_unc,
-                            double* val, double* grad);
+                            double* val, double* grad) const;
 
   /**
    * Calculate the log density, gradient, and Hessian for the
@@ -165,7 +165,7 @@ class bs_model_rng {
    * @param[in,out] hess Hessian produced
    */
   void log_density_hessian(bool propto, bool jacobian, const double* theta_unc,
-                           double* val, double* grad, double* hessian);
+                           double* val, double* grad, double* hessian) const;
 
   /**
    * Returns a lambda which calls the correct version of log_prob
@@ -175,7 +175,7 @@ class bs_model_rng {
    * @param[in] jacobian `true` to include Jacobian adjustment for
    * constrained parameter transforms
    */
-  auto make_model_lambda(bool propto, bool jacobian);
+  auto make_model_lambda(bool propto, bool jacobian) const;
 
  private:
   /** Stan model */


### PR DESCRIPTION
As pointed out by @aseyboldt in #88, our C headers could have many more things marked as `const` than they currently did. This fixes that and cleans up some argument names, also per his suggestion.