### PR TITLE
Expose version numbers in C API

### DIFF
--- a/R/R/bridgestan.R
+++ b/R/R/bridgestan.R
@@ -41,6 +41,12 @@ StanModel <- R6::R6Class("StanModel",
         stop("Could not construct model RNG.")
       }
       private$model <- ptr_out
+
+      model_version <- self$model_version()
+      if (packageVersion("bridgestan") != paste(model_version$major, model_version$minor, model_version$patch, sep = ".")) {
+        warning(paste0("The version of the compiled model does not match the version of the R library. ",
+                       "Consider recompiling the model."))
+      }
     },
     #' @description
     #' Get the name of this StanModel.

--- a/R/R/bridgestan.R
+++ b/R/R/bridgestan.R
@@ -60,6 +60,15 @@ StanModel <- R6::R6Class("StanModel",
         PACKAGE = private$lib_name
       )$info_out
     },
+
+    model_version= function() {
+      .C("bs_version_R",
+        major = as.integer(0),
+        minor = as.integer(0),
+        patch = as.integer(0),
+        PACKAGE = private$lib_name
+      )
+    },
     #' @description
     #' Return the indexed names of the (constrained) parameters.
     #' For containers, indexes are separated by periods (.).

--- a/c-example/example.c
+++ b/c-example/example.c
@@ -2,6 +2,9 @@
 #include <stdio.h>
 
 int main(int argc, char** argv) {
+  printf("Using BridgeStan version %d.%d.%d\n", bs_major_version,
+         bs_minor_version, bs_patch_version);
+
   char* data;
   if (argc > 1) {
     data = argv[1];

--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -120,6 +120,18 @@ function model_info(sm::StanModel)
 end
 
 """
+    model_version(sm)
+
+Return the BridgeStan version of the compiled model `sm`.
+"""
+function model_version(sm::StanModel)
+    major = reinterpret(Ptr{Cint}, Libc.Libdl.dlsym(sm.lib, "bs_major_version"))
+    minor = reinterpret(Ptr{Cint}, Libc.Libdl.dlsym(sm.lib, "bs_minor_version"))
+    patch = reinterpret(Ptr{Cint}, Libc.Libdl.dlsym(sm.lib, "bs_patch_version"))
+    (unsafe_load(major), unsafe_load(minor), unsafe_load(patch))
+end
+
+"""
     param_num(sm; include_tp=false, include_gq=false)
 
 Return the number of (constrained) parameters in the model.

--- a/python/bridgestan/__version.py
+++ b/python/bridgestan/__version.py
@@ -1,1 +1,2 @@
 __version__ = "1.0.2"
+__version_info__ = tuple(map(int, __version__.split(".")))

--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -1,10 +1,12 @@
 import ctypes
+import warnings
 from typing import List, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
 from numpy.ctypeslib import ndpointer
 
+from .__version import __version_info__
 from .compile import compile_model
 from .util import validate_readable
 
@@ -56,7 +58,7 @@ class StanModel:
             model from C++.
         """
         validate_readable(model_lib)
-        if not model_data is None and model_data.endswith('.json'):
+        if not model_data is None and model_data.endswith(".json"):
             validate_readable(model_data)
         self.lib_path = model_lib
         self.stanlib = ctypes.CDLL(self.lib_path)
@@ -74,6 +76,13 @@ class StanModel:
 
         if not self.model_rng:
             raise RuntimeError("could not construct model RNG")
+
+        if self.model_version() != __version_info__:
+            warnings.warn(
+                "The version of the compiled model does not match the version of the "
+                "Python package. Consider recompiling the model.",
+                RuntimeWarning,
+            )
 
         self._name = self.stanlib.bs_name
         self._name.restype = ctypes.c_char_p
@@ -226,6 +235,16 @@ class StanModel:
         :return: Information about the compiled Stan model.
         """
         return self._model_info(self.model_rng).decode("utf-8")
+
+    def model_version(self) -> Tuple[int, int, int]:
+        """
+        Return the BridgeStan version of the compiled model.
+        """
+        return (
+            ctypes.c_int.in_dll(self.stanlib, "bs_major_version").value,
+            ctypes.c_int.in_dll(self.stanlib, "bs_minor_version").value,
+            ctypes.c_int.in_dll(self.stanlib, "bs_patch_version").value,
+        )
 
     def param_num(self, *, include_tp: bool = False, include_gq: bool = False) -> int:
         """

--- a/src/bridgestan.cpp
+++ b/src/bridgestan.cpp
@@ -1,6 +1,11 @@
 #include "bridgestan.h"
 #include "model_rng.cpp"
 #include "bridgestanR.cpp"
+#include "version.hpp"
+
+int bs_major_version = BRIDGESTAN_MAJOR;
+int bs_minor_version = BRIDGESTAN_MINOR;
+int bs_patch_version = BRIDGESTAN_PATCH;
 
 bs_model_rng* bs_construct(const char* data_file, unsigned int seed,
                            unsigned int chain_id) {

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -8,6 +8,11 @@ extern "C" {
 typedef struct bs_model_rng bs_model_rng;
 typedef int bool;
 #endif
+
+extern int bs_major_version;
+extern int bs_minor_version;
+extern int bs_patch_version;
+
 /**
  * Construct an instance of a model and pseudorandom number
  * generator (PRNG) wrapper.  Data must be encoded in JSON as

--- a/src/bridgestanR.cpp
+++ b/src/bridgestanR.cpp
@@ -4,6 +4,11 @@
 void bs_construct_R(char** data, int* rng, int* chain, bs_model_rng** ptr_out) {
   *ptr_out = bs_construct(*data, *rng, *chain);
 }
+void bs_version_R(int* major, int* minor, int* patch){
+  *major = bs_major_version;
+  *minor = bs_minor_version;
+  *patch = bs_patch_version;
+}
 void bs_destruct_R(bs_model_rng** model, int* return_code) {
   *return_code = bs_destruct(*model);
 }

--- a/src/bridgestanR.h
+++ b/src/bridgestanR.h
@@ -13,6 +13,8 @@ typedef int bool;
 // All calls directly delegated to versions without _R suffix
 void bs_construct_R(char** data, int* rng, int* chain, bs_model_rng** ptr_out);
 
+void bs_version_R(int* major, int* minor, int* patch);
+
 void bs_destruct_R(bs_model_rng** model, int* return_code);
 
 void bs_name_R(bs_model_rng** model, char const** name_out);


### PR DESCRIPTION
Mentioned by @aseyboldt in #95. This adds three declarations to `bridgestan.h`:

```C
extern int bs_major_version;
extern int bs_minor_version;
extern int bs_patch_version;
```

Which are populated by the version number macros we already have in version.hpp. Previously, these versions were only available by pulling apart the string returned by `bs_model_info()`.


This also adds a warning to the Python interface if the model version and python library version differ. This should be rare, but good to check. We can do something similar in Julia in 1.9+ when it is released: [`pkgversion`](https://github.com/JuliaLang/julia/pull/45607)