### PR TITLE
Allow nullptr as data argument to constructor

### DIFF
--- a/c-example/example.c
+++ b/c-example/example.c
@@ -9,7 +9,7 @@ int main(int argc, char** argv) {
   if (argc > 1) {
     data = argv[1];
   } else {
-    data = "";
+    data = NULL;
   }
 
   // this could potentially error, and we may get information back about why.

--- a/src/bridgestan.cpp
+++ b/src/bridgestan.cpp
@@ -16,8 +16,8 @@ bs_model_rng* bs_construct(const char* data, unsigned int seed,
   } catch (const std::exception& e) {
     if (error_msg) {
       std::stringstream error;
-      error << "construct(" << data << ", " << seed << ", " << chain_id
-            << ")"
+      error << "construct(" << (data == nullptr ? "NULL" : data) << ", " << seed
+            << ", " << chain_id << ")"
             << " failed with exception: " << e.what() << std::endl;
       *error_msg = strdup(error.str().c_str());
     }
@@ -25,8 +25,8 @@ bs_model_rng* bs_construct(const char* data, unsigned int seed,
     if (error_msg) {
       std::stringstream error;
 
-      error << "construct(" << data << ", " << seed << ", " << chain_id
-            << ")"
+      error << "construct(" << (data == nullptr ? "NULL" : data) << ", " << seed
+            << ", " << chain_id << ")"
             << " failed with unknown exception" << std::endl;
       *error_msg = strdup(error.str().c_str());
     }

--- a/src/bridgestan.cpp
+++ b/src/bridgestan.cpp
@@ -9,14 +9,14 @@ int bs_patch_version = BRIDGESTAN_PATCH;
 
 #include <sstream>
 
-bs_model_rng* bs_construct(const char* data_file, unsigned int seed,
+bs_model_rng* bs_construct(const char* data, unsigned int seed,
                            unsigned int chain_id, char** error_msg) {
   try {
-    return new bs_model_rng(data_file, seed, chain_id);
+    return new bs_model_rng(data, seed, chain_id);
   } catch (const std::exception& e) {
     if (error_msg) {
       std::stringstream error;
-      error << "construct(" << data_file << ", " << seed << ", " << chain_id
+      error << "construct(" << data << ", " << seed << ", " << chain_id
             << ")"
             << " failed with exception: " << e.what() << std::endl;
       *error_msg = strdup(error.str().c_str());
@@ -25,7 +25,7 @@ bs_model_rng* bs_construct(const char* data_file, unsigned int seed,
     if (error_msg) {
       std::stringstream error;
 
-      error << "construct(" << data_file << ", " << seed << ", " << chain_id
+      error << "construct(" << data << ", " << seed << ", " << chain_id
             << ")"
             << " failed with unknown exception" << std::endl;
       *error_msg = strdup(error.str().c_str());

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -18,9 +18,9 @@ extern int bs_patch_version;
  * generator (PRNG) wrapper.  Data must be encoded in JSON as
  * indicated in the *CmdStan Reference Manual*.
  *
- * @param[in] data_file C-style string. This is either a
- * path to JSON-encoded data file (must end with ".json"), or
- * a JSON string literal.
+ * @param[in] data C-style string. This is either a
+ * path to JSON-encoded data file (must end with ".json"),
+ * a JSON string literal, or nullptr, which is interpreted as no data.
  * @param[in] seed seed for PRNG
  * @param[in] chain_id identifier for concurrent sequence of PRNG
  * draws
@@ -29,7 +29,7 @@ extern int bs_patch_version;
  * @return pointer to constructed model or `nullptr` if construction
  * fails
  */
-bs_model_rng* bs_construct(const char* data_file, unsigned int seed,
+bs_model_rng* bs_construct(const char* data, unsigned int seed,
                            unsigned int chain_id, char** error_msg);
 
 /**

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -20,7 +20,8 @@ extern int bs_patch_version;
  *
  * @param[in] data C-style string. This is either a
  * path to JSON-encoded data file (must end with ".json"),
- * a JSON string literal, or nullptr, which is interpreted as no data.
+ * a JSON string literal, or nullptr. An empty string or null
+ * pointer are both interpreted as no data.
  * @param[in] seed seed for PRNG
  * @param[in] chain_id identifier for concurrent sequence of PRNG
  * draws

--- a/src/model_rng.cpp
+++ b/src/model_rng.cpp
@@ -58,26 +58,32 @@ char* to_csv(const std::vector<std::string>& names) {
   return strdup(s_c);
 }
 
-bs_model_rng::bs_model_rng(const char* data_file, unsigned int seed,
+bs_model_rng::bs_model_rng(const char* data, unsigned int seed,
                            unsigned int chain_id) {
-  std::string data(data_file);
-  if (data.empty()) {
-    auto data_context = stan::io::empty_var_context();
+  if (data == nullptr) {
+    stan::io::empty_var_context data_context;
     model_ = &new_model(data_context, seed, &std::cout);
   } else {
-    if (stan::io::ends_with(".json", data)) {
-      std::ifstream in(data);
-      if (!in.good())
-        throw std::runtime_error("Cannot read input file: " + data);
-      auto data_context = stan::json::json_data(in);
-      in.close();
+    std::string data_str(data);
+    if (data_str.empty()) {
+      stan::io::empty_var_context data_context;
       model_ = &new_model(data_context, seed, &std::cout);
     } else {
-      std::istringstream json(data);
-      auto data_context = stan::json::json_data(json);
-      model_ = &new_model(data_context, seed, &std::cout);
+      if (stan::io::ends_with(".json", data_str)) {
+        std::ifstream in(data_str);
+        if (!in.good())
+          throw std::runtime_error("Cannot read input file: " + data_str);
+        stan::json::json_data data_context(in);
+        in.close();
+        model_ = &new_model(data_context, seed, &std::cout);
+      } else {
+        std::istringstream json(data_str);
+        stan::json::json_data data_context(json);
+        model_ = &new_model(data_context, seed, &std::cout);
+      }
     }
   }
+
   rng_ = stan::services::util::create_rng(seed, chain_id);
 
   std::string model_name = model_->model_name();

--- a/src/model_rng.hpp
+++ b/src/model_rng.hpp
@@ -18,12 +18,15 @@ class bs_model_rng {
    * Construct a model and random number generator with cached
    * parameter numbers and names.
    *
-   * @param[in] data_file file from which to read data or "" if none
+   * @param[in] data C-style string. This is either a
+   * path to JSON-encoded data file (must end with ".json"),
+   * a JSON string literal, or nullptr. An empty string or null
+   * pointer are both interpreted as no data.
    * @param[in] seed pseudorandom number generator seed
    * @param[in] chain_id number of gaps to skip in the pseudorandom
    * number generator for concurrent computations
    */
-  bs_model_rng(const char* data_file, unsigned int seed, unsigned int chain_id);
+  bs_model_rng(const char* data, unsigned int seed, unsigned int chain_id);
 
   /**
    * Destroy this object and free all of the memory allocated for it.


### PR DESCRIPTION
This was requested in #103.

Currently, you can specify a model has no data by passing "". This also allows you to pass `nullptr` for the same thing.