### PR TITLE
Update to Stan 2.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ print-%  : ; @echo $* = $($*) ;
 STANC_DL_RETRY = 5
 STANC_DL_DELAY = 10
 STANC3_TEST_BIN_URL ?=
-STANC3_VERSION ?= v2.31.0
+STANC3_VERSION ?= v2.32.0
 
 ifeq ($(OS),Windows_NT)
  OS_TAG := windows

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Stan is a probabilistic programming language for coding statistical
 models.  For an introduction to what can be coded in Stan, see the
 [*Stan User's Guide*](https://mc-stan.org/docs/stan-users-guide/index.html).
 
-BridgeStan is currently shipping with Stan version 2.31.0
+BridgeStan is currently shipping with Stan version 2.32.0
 
 Documentation is available at https://roualdes.github.io/bridgestan/
 

--- a/julia/test/model_tests.jl
+++ b/julia/test/model_tests.jl
@@ -659,7 +659,6 @@ end
     function f()
         println("Hello from Julia")
         BridgeStan.log_density(m, [theta])
-        Base.Libc.flush_cstdio() # NOTE: not necessary after Stan 2.32
     end
 
     out = @capture_out f()


### PR DESCRIPTION
This updates to the newly-released Stan 2.32.0 (see https://github.com/stan-dev/cmdstan/issues/1154)

The only change which are particularly relevant to BridgeStan are the flushing of print statements (see #108) and the changes to `get_dims` and `get_param_names` allowing us to delete a decent chunk of code we don't need