### PR TITLE
Add typedefs and variables to C API doc

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -164,10 +164,10 @@ jobs:
           submodules: recursive
 
       - name: Install R
-        uses: r-lib/actions/setup-r@v2.4.0
+        uses: r-lib/actions/setup-r@v2.6.2
 
       - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2.4.0
+        uses: r-lib/actions/setup-r-dependencies@v2.6.2
         with:
           packages: |
             any::R6
@@ -223,10 +223,10 @@ jobs:
           key: ${{ hashFiles('**/*.stan', 'src/*', 'stan/src/stan/version.hpp') }}-windows-latest-v${{ env.CACHE_VERSION }}
 
       - name: Install R
-        uses: r-lib/actions/setup-r@v2.4.0
+        uses: r-lib/actions/setup-r@v2.6.2
 
       - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2.4.0
+        uses: r-lib/actions/setup-r-dependencies@v2.6.2
         with:
           packages: |
             any::R6

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,6 @@ except Exception as e:
         raise e
     else:
         print("Breathe/doxygen not installed, skipping C++ Doc")
-        exclude_patterns += ["languages/cpp-api.rst"]
+        exclude_patterns += ["languages/c-api.rst"]
 else:
     extensions.append("breathe")

--- a/docs/languages/c-api.rst
+++ b/docs/languages/c-api.rst
@@ -40,7 +40,7 @@ These functions are implemented in C++, see :doc:`../internals` for more details
 
 .. autodoxygenfile:: bridgestan.h
     :project: bridgestan
-    :sections: func
+    :sections: func typedef var
 
 R-compatible functions
 ----------------------

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -6,13 +6,21 @@
 #include "callback_stream.hpp"
 extern "C" {
 #else
-#include <stddef.h>  // for size_t
-typedef struct bs_model bs_model;
-typedef struct bs_rng bs_rng;
+#include <stddef.h>   // for size_t
+#include <stdbool.h>  // for bool
+typedef struct bs_model bs_model;  ///< Opaque type for model
+typedef struct bs_rng bs_rng;      ///< Opaque type for RNG
+
+/** Type signature for optional print callback */
 typedef void (*STREAM_CALLBACK)(const char* data, size_t size);
-typedef int bool;
 #endif
 
+/**
+ * Version information for the BridgeStan library.
+ * @note These are *not* the version of the wrapped Stan library.
+ * @note These were not available pre-2.0.0, so their absence
+ * implies the library is in the 1.0.x series
+ */
 extern int bs_major_version;
 extern int bs_minor_version;
 extern int bs_patch_version;


### PR DESCRIPTION
Updates the C API doc to add the typedefs and variables in `bridgestan.h`