### PR TITLE
Windows: add TBB (and MinGW DLLs) to load path

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -233,6 +233,23 @@ jobs:
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install Python package
+        run: |
+          cd python/
+          pip install pytest
+          pip install .
+
+      - name: Run Python tests
+        run: |
+          $env:BRIDGESTAN = $(pwd)
+          cd python/
+          pytest -v
+          
       - name: Run Julia tests
         run: |
           $env:BRIDGESTAN = $(pwd)

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -211,9 +211,6 @@ jobs:
           path: ./stan/
           key: ${{ runner.os }}-stan-${{ hashFiles('stan/src/stan/version.hpp') }}-v${{ env.CACHE_VERSION }}
 
-      - name: Setup TBB
-        run: |
-          Add-Content $env:GITHUB_PATH "$(pwd)/stan/lib/stan_math/lib/tbb"
 
       - name: Restore built models
         uses: actions/cache@v3
@@ -240,6 +237,11 @@ jobs:
         run: |
           $env:BRIDGESTAN = $(pwd)
           julia --project=./julia -t 2 -e "using Pkg; Pkg.test()"
+
+      # needed for R tests until they have compilation utilities and can set this themselves.
+      - name: Set up TBB
+        run: |
+          Add-Content $env:GITHUB_PATH "$(pwd)/stan/lib/stan_math/lib/tbb"
 
       - name: Run R tests
         run: |

--- a/julia/src/BridgeStan.jl
+++ b/julia/src/BridgeStan.jl
@@ -43,4 +43,17 @@ StanModel(;
     seed = 204,
 ) = StanModel(compile_model(stan_file; stanc_args, make_args), data, seed)
 
+
+function __init__()
+    # On Windows, we may need to add TBB to %PATH%
+    if Sys.iswindows()
+        try
+            run(pipeline(`where.exe tbb.dll`, stdout=devnull, stderr=devnull))
+        catch
+            # add TBB to %PATH%
+            ENV["PATH"] = joinpath(get_bridgestan_path(), "stan", "lib", "stan_math", "lib", "tbb") * ";" * ENV["PATH"]
+        end
+    end
+end
+
 end

--- a/python/bridgestan/__init__.py
+++ b/python/bridgestan/__init__.py
@@ -3,3 +3,26 @@ from .compile import compile_model, set_bridgestan_path
 from .model import StanModel
 
 __all__ = ["StanModel", "set_bridgestan_path", "compile_model"]
+
+import platform as _plt
+
+if _plt.system() == "Windows":
+
+    def _windows_tbb_setup():
+        """Add tbb.dll to %PATH% on Windows."""
+        import os
+        import subprocess
+        from .compile import get_bridgestan_path
+
+        try:
+            subprocess.run(["where.exe", "tbb.dll"], check=True, capture_output=True)
+        except:
+            os.environ["PATH"] = (
+                os.path.join(
+                    get_bridgestan_path(), "stan", "lib", "stan_math", "lib", "tbb"
+                )
+                + ";"
+                + os.environ["PATH"]
+            )
+
+    _windows_tbb_setup()

--- a/python/bridgestan/__init__.py
+++ b/python/bridgestan/__init__.py
@@ -6,23 +6,38 @@ __all__ = ["StanModel", "set_bridgestan_path", "compile_model"]
 
 import platform as _plt
 
+
 if _plt.system() == "Windows":
 
-    def _windows_tbb_setup():
+    def _windows_path_setup():
         """Add tbb.dll to %PATH% on Windows."""
         import os
         import subprocess
+        import warnings
         from .compile import get_bridgestan_path
 
         try:
-            subprocess.run(["where.exe", "tbb.dll"], check=True, capture_output=True)
+            out = subprocess.run(["where.exe", "tbb.dll"], check=True, capture_output=True)
+            tbb_path = os.path.dirname(out.stdout.decode().splitlines()[0])
+            os.add_dll_directory(tbb_path)
         except:
-            os.environ["PATH"] = (
-                os.path.join(
-                    get_bridgestan_path(), "stan", "lib", "stan_math", "lib", "tbb"
-                )
-                + ";"
-                + os.environ["PATH"]
+            tbb_path = os.path.join(
+                get_bridgestan_path(), "stan", "lib", "stan_math", "lib", "tbb"
+            )
+            os.environ["PATH"] = tbb_path + ";" + os.environ["PATH"]
+            os.add_dll_directory(tbb_path)
+
+        try:
+            out = subprocess.run(
+                ["where.exe", "libwinpthread-1.dll"], check=True, capture_output=True
+            )
+            mingw_dir = os.path.dirname(out.stdout.decode().splitlines()[0])
+            os.add_dll_directory(mingw_dir)
+        except:
+            # no default location
+            warnings.warn(
+                "Unable to find MinGW's DLL location. Loading BridgeStan models may fail.",
+                RuntimeWarning,
             )
 
-    _windows_tbb_setup()
+    _windows_path_setup()

--- a/python/bridgestan/__init__.py
+++ b/python/bridgestan/__init__.py
@@ -29,7 +29,7 @@ if _plt.system() == "Windows":
 
         try:
             out = subprocess.run(
-                ["where.exe", "libwinpthread-1.dll"], check=True, capture_output=True
+                ["where.exe", "libwinpthread-1.dll", "libgcc_s_seh-1.dll", "libstdc++-6.dll"], check=True, capture_output=True
             )
             mingw_dir = os.path.dirname(out.stdout.decode().splitlines()[0])
             os.add_dll_directory(mingw_dir)

--- a/python/test/test_stanmodel.py
+++ b/python/test/test_stanmodel.py
@@ -710,7 +710,7 @@ def recompile_simple():
     lib.unlink(missing_ok=True)
     res = bs.compile_model(stanfile, make_args=["BRIDGESTAN_AD_HESSIAN=true"])
 
-    yield res
+    yield str(res)
 
     lib.unlink(missing_ok=True)
     bs.compile_model(stanfile, make_args=["STAN_THREADS=true"])


### PR DESCRIPTION
This is in response to #117. It isn't a full "fix" (arbitrary user configs could still run into similar problems and need to set their own `%PATH%`s correctly), but it attempts to be a bit friendlier.

This is similar to code in [cmdstanpy](https://github.com/stan-dev/cmdstanpy/blob/cd650840d9b8dec02b98d563bcdf88ccefb10fff/cmdstanpy/model.py#L216-L223). The main difference is (in Python) it also uses [`os.add_dll_directory`](https://docs.python.org/3/library/os.html#os.add_dll_directory). This appears to have fixed the issue which was preventing us from running our Python tests on Windows in Github Actions, so I've re-enabled those.

I'll do a follow on PR which tries to split the Windows CI in to separate jobs per-interface. 

Note: This PR does not change the R interface, since R doesn't (yet) have any handling of where BridgeStan is installed (see #100)