### PR TITLE
Split Windows CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,18 +31,18 @@ jobs:
           path: ./stan/
           key: ${{ runner.os }}-stan-${{ hashFiles('stan/src/stan/version.hpp') }}-v${{ env.CACHE_VERSION }}
 
-      # - name: Build C example (Unix)
-      #   if: matrix.os != 'windows-latest'
-      #   run: |
-      #     cd c-example/
-      #     make example
-      #     make example_static
-      #     rm ../src/bridgestan.o
-      #     rm ../test_models/full/full_model.a
+      - name: Build C example (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          cd c-example/
+          make example
+          make example_static
+          rm ../src/bridgestan.o
+          rm ../test_models/full/full_model.a
 
-      #     ./example
-      #     ./example_static
-      #   shell: bash
+          ./example
+          ./example_static
+        shell: bash
 
       # we use the cache here to build the Stan models once for multiple interfaces
       - name: Set up test model cache
@@ -105,15 +105,19 @@ jobs:
 
       - name: Run tests
         run: |
-          cd python/
-          pytest -v
-          pytest -v --run-type=ad_hessian
+          pytest -v python/
         env:
           BRIDGESTAN: ${{ github.workspace }}
 
+      - name: Run tests (Unix-specific)
+        run: |
+          pytest -v python/ --run-type=ad_hessian
+        env:
+          BRIDGESTAN: ${{ github.workspace }}
+
+
   julia:
     needs: [build]
-
     runs-on: ${{matrix.os}}
     strategy:
       matrix:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ env:
   CACHE_VERSION: 0
 
 jobs:
-  build_test_models:
+  build:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -64,8 +64,8 @@ jobs:
           mingw32-make.exe STAN_THREADS=true O=0 test_models -j2
         shell: pwsh
 
-  test_python_client:
-    needs: [build_test_models]
+  python:
+    needs: [build]
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -110,12 +110,13 @@ jobs:
           pytest -v
           pytest -v --run-type=ad_hessian
 
-  test_julia_client:
-    needs: [build_test_models]
+  julia:
+    needs: [build]
+
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         julia-version: ["1"]
         include:
           - julia-version: "1.6"
@@ -147,11 +148,12 @@ jobs:
 
       - name: Run tests
         run: |
-          export BRIDGESTAN=$(pwd)
           julia --project=./julia -t 2 -e "using Pkg; Pkg.test()"
+        env:
+          BRIDGESTAN: ${{ github.workspace }}
 
-  test_R_client:
-    needs: [build_test_models]
+  Rlang:
+    needs: [build]
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -196,7 +198,7 @@ jobs:
 
   # Seperate for now, weird dynamic linking issues need resolving in GHA runner
   test_clients_windows:
-    needs: [build_test_models]
+    needs: [build]
     runs-on: windows-latest
     steps:
       - name: Check out github
@@ -249,11 +251,6 @@ jobs:
           $env:BRIDGESTAN = $(pwd)
           cd python/
           pytest -v
-          
-      - name: Run Julia tests
-        run: |
-          $env:BRIDGESTAN = $(pwd)
-          julia --project=./julia -t 2 -e "using Pkg; Pkg.test()"
 
       # needed for R tests until they have compilation utilities and can set this themselves.
       - name: Set up TBB

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9, "3.10"]
       fail-fast: false
     steps:
@@ -133,6 +133,7 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
+
       - name: Restore Stan
         uses: actions/cache@v3
         id: stan-cache
@@ -197,54 +198,17 @@ jobs:
           Add-Content $env:GITHUB_PATH "$(pwd)/stan/lib/stan_math/lib/tbb"
 
       - name: Run tests
+        if: matrix.os != 'windows-latest'
         run: |
           cd R/tests/testthat
           gcc -fpic -shared -o test_collisions.so test_collisions.c
           cd ../..
           Rscript -e "devtools::test(reporter = c(\"summary\", \"fail\"))"
 
-  # Seperate for now, weird dynamic linking issues need resolving in GHA runner
-  test_clients_windows:
-    needs: [build]
-    runs-on: windows-latest
-    steps:
-      - name: Check out github
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Restore Stan
-        uses: actions/cache@v3
-        id: stan-cache
-        with:
-          path: ./stan/
-          key: ${{ runner.os }}-stan-${{ hashFiles('stan/src/stan/version.hpp') }}-v${{ env.CACHE_VERSION }}
-
-
-      - name: Restore built models
-        uses: actions/cache@v3
-        id: test-models
-        with:
-          path: ./test_models/
-          key: ${{ hashFiles('**/*.stan', 'src/*', 'stan/src/stan/version.hpp', 'Makefile') }}-windows-latest-v${{ env.CACHE_VERSION }}
-
-      - name: Set up Julia
-        uses: julia-actions/setup-julia@v1
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-
-      - name: Install Python package
+      - name: Run tests (windows)
+        if: matrix.os == 'windows-latest'
         run: |
-          cd python/
-          pip install pytest
-          pip install .
-
-      - name: Run Python tests
-        run: |
-          $env:BRIDGESTAN = $(pwd)
-          cd python/
-          pytest -v
-
+          cd R/tests/testthat
+          gcc -fpic -shared -o test_collisions.dll test_collisions.c
+          cd ../..
+          Rscript -e 'devtools::test(reporter = c(\"summary\", \"fail\"))'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,10 +105,11 @@ jobs:
 
       - name: Run tests
         run: |
-          export BRIDGESTAN=$(pwd)
           cd python/
           pytest -v
           pytest -v --run-type=ad_hessian
+        env:
+          BRIDGESTAN: ${{ github.workspace }}
 
   julia:
     needs: [build]
@@ -157,7 +158,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     steps:
       - name: Check out github
@@ -188,6 +189,12 @@ jobs:
         with:
           path: ./test_models/
           key: ${{ hashFiles('**/*.stan', 'src/*', 'stan/src/stan/version.hpp', 'Makefile') }}-${{ matrix.os }}-v${{ env.CACHE_VERSION }}
+
+      # needed for R tests until they have compilation utilities and can set this themselves.
+      - name: Set up TBB
+        if: matrix.os == 'windows-latest'
+        run: |
+          Add-Content $env:GITHUB_PATH "$(pwd)/stan/lib/stan_math/lib/tbb"
 
       - name: Run tests
         run: |
@@ -221,17 +228,6 @@ jobs:
           path: ./test_models/
           key: ${{ hashFiles('**/*.stan', 'src/*', 'stan/src/stan/version.hpp', 'Makefile') }}-windows-latest-v${{ env.CACHE_VERSION }}
 
-      - name: Install R
-        uses: r-lib/actions/setup-r@v2.6.3
-
-      - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2.6.3
-        with:
-          packages: |
-            any::R6
-            any::testthat
-            any::devtools
-
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
 
@@ -252,14 +248,3 @@ jobs:
           cd python/
           pytest -v
 
-      # needed for R tests until they have compilation utilities and can set this themselves.
-      - name: Set up TBB
-        run: |
-          Add-Content $env:GITHUB_PATH "$(pwd)/stan/lib/stan_math/lib/tbb"
-
-      - name: Run R tests
-        run: |
-          cd R/tests/testthat
-          gcc -fpic -shared -o test_collisions.dll test_collisions.c
-          cd ../..
-          Rscript -e 'devtools::test(reporter = c(\"summary\", \"fail\"))'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,18 +31,18 @@ jobs:
           path: ./stan/
           key: ${{ runner.os }}-stan-${{ hashFiles('stan/src/stan/version.hpp') }}-v${{ env.CACHE_VERSION }}
 
-      - name: Build C example (Unix)
-        if: matrix.os != 'windows-latest'
-        run: |
-          cd c-example/
-          make example
-          make example_static
-          rm ../src/bridgestan.o
-          rm ../test_models/full/full_model.a
+      # - name: Build C example (Unix)
+      #   if: matrix.os != 'windows-latest'
+      #   run: |
+      #     cd c-example/
+      #     make example
+      #     make example_static
+      #     rm ../src/bridgestan.o
+      #     rm ../test_models/full/full_model.a
 
-          ./example
-          ./example_static
-        shell: bash
+      #     ./example
+      #     ./example_static
+      #   shell: bash
 
       # we use the cache here to build the Stan models once for multiple interfaces
       - name: Set up test model cache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -110,6 +110,7 @@ jobs:
           BRIDGESTAN: ${{ github.workspace }}
 
       - name: Run tests (Unix-specific)
+        if: matrix.os != 'windows-latest'
         run: |
           pytest -v python/ --run-type=ad_hessian
         env:


### PR DESCRIPTION
This is based on #118 and should be merged second. Dramatically cleans up our CI action and makes Windows tests more similar to the other platforms.