### PR TITLE
Fix R example and run examples in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,7 +105,9 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -v python/
+          cd python/
+          python example.py
+          pytest -v
         env:
           BRIDGESTAN: ${{ github.workspace }}
 
@@ -155,7 +157,9 @@ jobs:
 
       - name: Run tests
         run: |
-          julia --project=./julia -t 2 -e "using Pkg; Pkg.test()"
+          cd julia/
+          julia --project=. example.jl
+          julia --project=. -t 2 -e "using Pkg; Pkg.test()"
         env:
           BRIDGESTAN: ${{ github.workspace }}
 
@@ -208,6 +212,7 @@ jobs:
           cd R/tests/testthat
           gcc -fpic -shared -o test_collisions.so test_collisions.c
           cd ../..
+          Rscript example.R
           Rscript -e "devtools::test(reporter = c(\"summary\", \"fail\"))"
 
       - name: Run tests (windows)
@@ -216,4 +221,5 @@ jobs:
           cd R/tests/testthat
           gcc -fpic -shared -o test_collisions.dll test_collisions.c
           cd ../..
+          Rscript example.R
           Rscript -e 'devtools::test(reporter = c(\"summary\", \"fail\"))'

--- a/R/example.R
+++ b/R/example.R
@@ -1,10 +1,10 @@
-# Before running this: 
+# Before running this:
 #  - In the terminal, run `make test_models/bernoulli/bernoulli_model.so` from inside the bridgestan folder
-#  - In R, make sure you are in the directory bridgestan/R 
+#  - In R, make sure you are in the directory bridgestan/R
 
 library(bridgestan)
 
-model <- StanModel$new("../test_models/bernoulli/bernoulli_model.so", "../test_models/bernoulli/bernoulli.data.json", 1234, 0)
+model <- StanModel$new("../test_models/bernoulli/bernoulli_model.so", "../test_models/bernoulli/bernoulli.data.json", 1234)
 
 print(paste0("This model's name is ", model$name(), "."))
 print(paste0("This model has ", model$param_num(), " parameters."))

--- a/python/example.py
+++ b/python/example.py
@@ -1,6 +1,8 @@
 import bridgestan as bs
 import numpy as np
 
+bs.set_bridgestan_path("../")
+
 stan = "../test_models/bernoulli/bernoulli.stan"
 data = "../test_models/bernoulli/bernoulli.data.json"
 model = bs.StanModel.from_stan_file(stan, data)


### PR DESCRIPTION
This closes #121 by removing the extra argument (left over from pre- #98) and also adds a line to run each example program as part of our CI to make sure they stay up-to-date.