### PR TITLE
R: Allow NaN and Inf to be passed in foreign function calls

### DIFF
--- a/R/R/bridgestan.R
+++ b/R/R/bridgestan.R
@@ -165,6 +165,7 @@ StanModel <- R6::R6Class("StanModel",
         return_code = as.integer(0),
         err_msg = as.character(""),
         err_ptr = raw(8),
+        NAOK = TRUE,
         PACKAGE = private$lib_name
       )
 
@@ -196,6 +197,7 @@ StanModel <- R6::R6Class("StanModel",
         return_code = as.integer(0),
         err_msg = as.character(""),
         err_ptr = raw(8),
+        NAOK = TRUE,
         PACKAGE = private$lib_name
       )
       if (vars$return_code) {
@@ -237,6 +239,7 @@ StanModel <- R6::R6Class("StanModel",
         return_code = as.integer(0),
         err_msg = as.character(""),
         err_ptr = raw(8),
+        NAOK = TRUE,
         PACKAGE = private$lib_name
       )
       if (vars$return_code) {
@@ -259,6 +262,7 @@ StanModel <- R6::R6Class("StanModel",
         return_code = as.integer(0),
         err_msg = as.character(""),
         err_ptr = raw(8),
+        NAOK = TRUE,
         PACKAGE = private$lib_name
       )
       if (vars$return_code) {
@@ -281,6 +285,7 @@ StanModel <- R6::R6Class("StanModel",
         return_code = as.integer(0),
         err_msg = as.character(""),
         err_ptr = raw(8),
+        NAOK = TRUE,
         PACKAGE = private$lib_name
       )
       if (vars$return_code) {

--- a/R/tests/testthat/test-bridgestan.R
+++ b/R/tests/testthat/test-bridgestan.R
@@ -31,11 +31,24 @@ test_that("simple_model has 5 unconstrained parameters", {
     expect_equal(simple$param_unc_num(), 5)
 })
 
-
 test_that("simple_model grad(x) is -x",{
     x <- runif(5)
     expect_equal(-x, simple$log_density_gradient(x)$gradient)
 })
+
+
+test_that("models can be passed NAN or INF", {
+    x <- runif(5)
+    x[1] <- NaN
+    x[2] <- Inf
+    x[3] <- -Inf
+    grad <- simple$log_density_gradient(x)$gradient
+    expect_equal(-x, grad)
+    expect_true(is.nan(grad[1]))
+    expect_true(is.infinite(grad[2]))
+    expect_true(is.infinite(grad[3]))
+})
+
 
 test_that("simple_model Hessian is -I",{
     x <- runif(5)


### PR DESCRIPTION
While reading more in the R documentation as part of debugging #131, I noticed this additional flag we should be using (`NAOK = TRUE`):

> Unless formal argument NAOK is true, all the other arguments are checked for missing values NA and for the IEEE special values NaN, Inf and -Inf, and the presence of any of these generates an error. If it is true, these values are passed unchecked. 

NaN/infinity are valid inputs to Stan programs, so we should be allowing them.