### PR TITLE
Add to Julia interface docs required STAN_THREADS for tests

### DIFF
--- a/julia/docs/src/julia.md
+++ b/julia/docs/src/julia.md
@@ -66,6 +66,14 @@ An example program is provided alongside the Julia interface code in `example.jl
 </details>
 ```
 
+## Tests
+
+Julia's multi-threading capabilities allow different processors/threads to make
+simultaneous calls to the BridgeStan API.  Such capabilities require the target
+Stan program to be compiled with `STAN_THREADS=true`, see the function
+`compile_model` for more details.  The Julia interface tests this feature and
+thus requires `STAN_THREADS=true` for the tests to run successfully.
+
 ## API Reference
 
 ### StanModel interface


### PR DESCRIPTION
This PR addresses issue [#145](https://github.com/roualdes/bridgestan/issues/145) by adding a section to the Julia interface docs detailing the multi-threaded capabilities of Julia, how they coordinate with the BridgeStan API, and the fact that we test against this, thus requiring `STAN_THREADS=true` to be set for our Julia tests to run successfully.

I'd prefer to link to the function `compile_model`, but I don't know how to set up an internal link to that specific anchor in our docs.