### PR TITLE
fix(rust): Allow loading more recent libraries

### DIFF
--- a/rust/src/bs_safe.rs
+++ b/rust/src/bs_safe.rs
@@ -124,7 +124,7 @@ pub fn open_library<P: AsRef<OsStr>>(path: P) -> Result<StanLibrary> {
     let self_minor: c_int = env!("CARGO_PKG_VERSION_MINOR").parse().unwrap();
     let self_patch: c_int = env!("CARGO_PKG_VERSION_PATCH").parse().unwrap();
 
-    if (self_major != major) | (self_minor != minor) {
+    if !((self_major == major) & (self_minor <= minor)) {
         return Err(BridgeStanError::BadLibraryVersion(
             format!("{}.{}.{}", major, minor, patch),
             format!("{}.{}.{}", self_major, self_minor, self_patch),


### PR DESCRIPTION
I think it should be legal to provide a bridgestan library that was compiled with a later version of bridgestan, if the major version still matches. But the rust wrapper expects an exact version match right now. This means that downstream rust libraries have to specify an exact version of the python bridgestan library, or a user could update the python library and libraries built by that new bridgestan couldn't be loaded anymore.

Supporting *older* libraries would be some work, as we would have to handle the case that symbols might be missing in the library, so we still don't allow that.

This change would also imply that the ABI can't change without a major version bump. I can't really think of reasons why that would be a problem though...