### PR TITLE
Docs: Formatting tweaks and fixes

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,7 @@
+html[data-theme="light"] {
+    --pst-color-inline-code: #83BA73;
+}
+
+html[data-theme="dark"] {
+    --pst-color-inline-code: #659157;
+}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,5 +1,5 @@
 html[data-theme="light"] {
-    --pst-color-inline-code: #83BA73;
+    --pst-color-inline-code: #008000;
 }
 
 html[data-theme="dark"] {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,7 @@ html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 html_css_files = [
     "css/Documenter.css",
+    "css/custom.css",
 ]
 
 html_show_sphinx = False

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -8,7 +8,7 @@ Requirement: C++ toolchain
 Stan requires a C++ tool chain consisting of
 
 * A C++14 compiler. On Windows, MSCV is *not* supported, so something like MinGW GCC is required.
-* The Gnu ``make`` utility for \*nix *or* ``mingw32-make`` for Windows
+* The Gnu :command:`make` utility for \*nix *or* :command:`mingw32-make` for Windows
 
 Here are complete instructions by platform for installing both, from the CmdStan installation instructions.
 
@@ -36,10 +36,10 @@ To use these, simply download the file associated with the version you wish to u
 and unzip its contents into the folder you would like BridgeStan to be in.
 
 
-Installing the latest version with ``git``
-__________________________________________
+Installing the latest version with :command:`git`
+_________________________________________________
 
-If you have ``git`` installed, you may download BridgeStan by navigating to the folder you'd like
+If you have :command:`git` installed, you may download BridgeStan by navigating to the folder you'd like
 BridgeStan to be in and running
 
 .. code-block:: shell
@@ -64,10 +64,10 @@ a terminal in your BridgeStan folder and running
     # Windows
     mingw32-make.exe test_models/multi/multi_model.so
 
-This will compile the file ``test_models/multi/multi.stan`` into a shared library object for use with BridgeStan.
+This will compile the file :file:`test_models/multi/multi.stan` into a shared library object for use with BridgeStan.
 This will require internet access the first time you run it in order
 to download the appropriate Stan compiler for your platform into
-``<bridgestan-dir>/bin/stanc[.exe]``
+:file:`{<bridgestan-dir>}/bin/stanc{[.exe]}`
 
 Installing an Interface
 -----------------------
@@ -81,10 +81,10 @@ Optional: Customizing BridgeStan
 BridgeStan has many compiler flags and options set by default. Many of these defaults
 are the same as those used by the CmdStan interface to Stan.
 You can override the defaults or add new flags
-on the command line when invoking ``make``, or make them persistent by
-creating or editing the file ``<bridgestan dir>/make/local``.
+on the command line when invoking :command:`make`, or make them persistent by
+creating or editing the file :file:`{<bridgestan dir>}/make/local`.
 
-For example, setting the contents of ``make/local`` to the following
+For example, setting the contents of :file:`make/local` to the following
 includes compiler flags for optimization level and architecture.
 
 .. code-block:: Makefile
@@ -94,7 +94,7 @@ includes compiler flags for optimization level and architecture.
     # Adding other arbitrary C++ compiler flags
     CXXFLAGS+= -march=native
 
-Flags for ``stanc3`` can also be set here
+Flags for :command:`stanc3` can also be set here
 
 .. code-block:: Makefile
 
@@ -106,7 +106,7 @@ ________________________________________
 
 In order for Python or Julia to be able to call a single Stan model
 concurrently from multiple threads or for a Stan model to execute its
-own code in parallel, the following flag must be set in ``make/local``
+own code in parallel, the following flag must be set in :file:`make/local`
 or on the command line.
 
 .. code-block:: Makefile
@@ -116,7 +116,7 @@ or on the command line.
 
 Note that this flag changes a lot of the internals of the Stan library
 and as such, **all models used in the same process should have the same
-setting**. Mixing models which have ``STAN_THREADS`` enabled with those that do not
+setting**. Mixing models which have :makevar:`STAN_THREADS` enabled with those that do not
 will most likely lead to segmentation faults or other crashes.
 
 Additional flags, such as those for MPI and OpenCL, are covered in the
@@ -131,12 +131,12 @@ to be computed directly, particularly models which use implicit functions like t
 or ODE integrators.
 
 If your Stan model does not use these features, you can enable autodiff Hessians by
-setting the compile-time flag ``BRIDGESTAN_AD_HESSIAN=true`` in the invocation to ``make``.
-This can be set in ``make/local`` if you wish to use it by default.
+setting the compile-time flag ``BRIDGESTAN_AD_HESSIAN=true`` in the invocation to :command:`make`.
+This can be set in :file:`make/local` if you wish to use it by default.
 
 This value is reported by the ``model_info`` function if you would like to check at run time
 whether Hessians are computed with nested autodiff or with finite differences. Similar to
-``STAN_THREADS``, it is not advised to mix models which use autodiff Hessians with those that
+:makevar:`STAN_THREADS`, it is not advised to mix models which use autodiff Hessians with those that
 do not in the same program.
 
 Autodiff Hessians may be faster than finite differences depending on your model, and will
@@ -147,21 +147,21 @@ __________________________
 
 If you wish to use BridgeStan for an older released version, all you need to do is
 
-1. Set ``STANC3_VERSION`` in ``make/local`` to your desired version, e.g. ``v2.26.0``
+1. Set :makevar:`STANC3_VERSION` in :file:`make/local` to your desired version, e.g. ``v2.26.0``
 2. Go into the ``stan`` submodule and run ``git checkout release/VERSION``, e.g. ``release/v2.26.0``
 3. Also in the ``stan`` submodule, run ``make math-update``
 4. In the top level BridgeStan directory, run ``make clean``
 
 To return to the version of Stan currently used by BridgeStan, you can run ``make stan-update`` from the top level directory
-and remove ``STANC3_VERSION`` from your ``make/local`` file, before running ``make clean`` again.
+and remove :makevar:`STANC3_VERSION` from your ``make/local`` file, before running ``make clean`` again.
 
 Using Pre-Existing Stan Installations
 _____________________________________
 
 If you wish to use BridgeStan with a pre-existing download of the Stan repository, or with
-a custom fork or branch, you can set the ``STAN`` (and, optionally, ``MATH``) variables to the
-path to your existing copy in calls to ``make``, or more permanently by setting them in a
-``make/local`` file as described above.
+a custom fork or branch, you can set the :makevar:`STAN` (and, optionally, :makevar:`MATH`) variables to the
+path to your existing copy in calls to :command:`make`, or more permanently by setting them in a
+:file:`make/local` file as described above.
 
 The easiest way to use a custom stanc3 is to place the built executable at
-``bin/stanc[.exe]``.
+:file:`bin/stanc{[.exe]}`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,9 @@
-.. BridgeStan documentation master file, created by
-   sphinx-quickstart on Fri Sep  2 11:44:11 2022.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
 
 Welcome to BridgeStan's documentation!
 ======================================
 
 BridgeStan provides efficient in-memory access through Python, Julia,
-and R to the methods of a `Stan <https://mc-stan.org>`__ model, including
+R, and Rust to the methods of a `Stan <https://mc-stan.org>`__ model, including
 log densities, gradients, Hessians, and constraining and unconstraining
 transforms.
 

--- a/docs/internals/documentation.rst
+++ b/docs/internals/documentation.rst
@@ -11,7 +11,7 @@ generation (powered by `Sphinx <https://www.sphinx-doc.org/en/master/>`__) autom
 combines these together into the documentation you are reading now.
 
 To build the documentation, you can run ``make docs`` in the top-level directory.
-This places the files in ``docs/_build/html``. At a minimum, the following must be installed:
+This places the files in :file:`docs/_build/html`. At a minimum, the following must be installed:
 
 * The Python interface to BridgeStan
 * `Sphinx 5.0 or above <https://www.sphinx-doc.org/en/master/>`__
@@ -28,6 +28,6 @@ If you wish to build the C++ portions of the documentation, you should also have
 * `Breathe <https://breathe.readthedocs.io/en/stable/index.html>`__
 
 Similarly, the Julia documentation will only update if Julia is installed. Julia
-documentation is written in ``julia/docs/src/julia.md``. We then build
+documentation is written in :file:`julia/docs/src/julia.md`. We then build
 this with `DocumenterMarkdown.jl <https://github.com/JuliaDocs/DocumenterMarkdown.jl>`__,
-and the output is placed in ``docs/languages/julia.md``.
+and the output is placed in :file:`docs/languages/julia.md`.

--- a/docs/internals/ffi.rst
+++ b/docs/internals/ffi.rst
@@ -93,10 +93,10 @@ library in order to be freed.
 Output Streams
 ______________
 
-Printed output from the C++ code cannot easily be captured in the higher-level language.
-This is particularly relevant for error messaging, which is printed to the standard
-error output ``stderr`` from C++. This does *not*, for example, correspond to the
-``sys.stderr`` stream available from Python.
+Printed output from the C++ code cannot always be easily captured in the higher-level language.
+This is particularly relevant for print statements in Stan, which are printed to the standard
+output ``stdout`` from C++. This does *not*, for example, correspond to the
+:py:data:`sys.stdout` stream available from Python by default.
 
 We tackle this problem through the use of an interface-provided callback function
-when necessary.
+when necessary. See :cpp:func:`bs_set_print_callback()` for more details.

--- a/docs/internals/testing.rst
+++ b/docs/internals/testing.rst
@@ -3,7 +3,7 @@ Testing
 
 Testing for BridgeStan is primarily done through the higher-level :doc:`interfaces <../languages>`.
 
-All tests are based around the same set of test models (in the ``test_models/`` folder).
+All tests are based around the same set of test models (in the :file:`test_models/` folder).
 
 You can build all of the test models at once with
 
@@ -12,7 +12,7 @@ You can build all of the test models at once with
     make STAN_THREADS=true test_models -j<jobs>
 
 Note: The additional functionality provided by
-``STAN_THREADS`` is only tested by the Julia tests,
+:makevar:`STAN_THREADS` is only required by the Julia and Rust tests,
 but in order to facilitate the same built models being used in
 all tests we use it regardless of interface.
 
@@ -26,7 +26,7 @@ In Python we use `pytest <https://docs.pytest.org/en/7.2.x/>`__ to run tests. Te
 are written using basic ``assert`` statements and helper code from :py:mod:`numpy.testing`.
 
 The Python test suite has the ability to run mutually exclusive groups of code. This is to allow
-testing of features such as the ``BRIDGESTAN_AD_HESSIAN`` flag which change underlying code and
+testing of features such as the :makevar:`BRIDGESTAN_AD_HESSIAN` flag which change underlying code and
 therefore cannot be loaded at the same time as models compiled without it.
 
 Running
@@ -43,7 +43,7 @@ Will run the "default" grouping. To run the other group(s), run
     cd python/
     pytest --run-type=ad_hessian -v
 
-The set up for this can be seen in ``tests/conftest.py`` and is based on the
+The set up for this can be seen in :file:`tests/conftest.py` and is based on the
 `Pytest documentation examples <https://docs.pytest.org/en/7.1.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option>`__.
 
 Julia
@@ -68,3 +68,13 @@ R tests are written using `testthat <https://testthat.r-lib.org/>`__.
     Rscript -e "devtools::test()"
 
 The R unit tests are much more basic than the Python or Julia tests.
+
+Rust
+_____
+
+The R tests can be run with :command:`cargo`
+
+.. code-block:: shell
+
+    cd rust/
+    cargo test

--- a/docs/internals/testing.rst
+++ b/docs/internals/testing.rst
@@ -72,7 +72,7 @@ The R unit tests are much more basic than the Python or Julia tests.
 Rust
 _____
 
-The R tests can be run with :command:`cargo`
+The Rust tests can be run with :command:`cargo`
 
 .. code-block:: shell
 

--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -10,7 +10,7 @@ All language interfaces expose the same core functionality from the
 :doc:`C API <./languages/c-api>`.
 Additional "quality of life" features such as the ability to download
 BridgeStan's source code automatically or compile models from inside the language
-(rather than manually calling ``make``) are available on a best-effort basis.
+(rather than manually calling :command:`make`) are available on a best-effort basis.
 If you are missing these features in your favorite language, we would welcome a
 `contribution <https://github.com/roualdes/bridgestan/blob/main/CONTRIBUTING.md>`__!
 

--- a/docs/languages/c-api.rst
+++ b/docs/languages/c-api.rst
@@ -13,8 +13,8 @@ BridgeStan's pre-requisites and downloaded a copy of the BridgeStan source code.
 Example Program
 ---------------
 
-An example program is provided alongside the BridgeStan source in ``c-example/``.
-Details for building the example can be found in ``c-example/Makefile``.
+An example program is provided alongside the BridgeStan source in :file:`c-example/`.
+Details for building the example can be found in :file:`c-example/Makefile`.
 
 .. raw:: html
 
@@ -33,7 +33,7 @@ Details for building the example can be found in ``c-example/Makefile``.
 API Reference
 -------------
 
-The following are the C functions exposed by the BridgeStan library in ``bridgestan.h``.
+The following are the C functions exposed by the BridgeStan library in :file:`bridgestan.h`.
 These are wrapped in the various high-level interfaces.
 
 These functions are implemented in C++, see :doc:`../internals` for more details.
@@ -46,7 +46,7 @@ R-compatible functions
 ----------------------
 
 To support calling these functions from R without including R-specific headers
-into the project, the following functions are exposed in ``bridgestanR.h``.
+into the project, the following functions are exposed in :file:`bridgestanR.h`.
 
 These are small shims which call the above functions. All arguments and return values
 must be handeled via pointers.

--- a/docs/languages/python.rst
+++ b/docs/languages/python.rst
@@ -19,7 +19,7 @@ For convience, BridgeStan is uploaded to the Python Package Index each release.
 
 
 The first time you need it, the BridgeStan source code will be downloaded
-and placed in ``~/.bridgestan/``. If you prefer to use a source distribution of BridgeStan,
+and placed in :file:`~/.bridgestan/`. If you prefer to use a source distribution of BridgeStan,
 consult the following section.
 
 
@@ -53,7 +53,7 @@ NumPy if it is not already installed.
 Example Program
 ---------------
 
-An example program is provided alongside the Python interface code in ``example.py``:
+An example program is provided alongside the Python interface code in :file:`example.py`:
 
 .. raw:: html
 

--- a/docs/languages/rust.rst
+++ b/docs/languages/rust.rst
@@ -8,7 +8,7 @@ Rust Interface
 Installation
 ------------
 
-The BridgeStan Rust client is available on `crates.io <https://crates.io/crates/bridgestan>`__ and via ``cargo``:
+The BridgeStan Rust client is available on `crates.io <https://crates.io/crates/bridgestan>`__ and via :command:`cargo`:
 
 .. code-block:: shell
 
@@ -25,7 +25,7 @@ details see the `API reference <https://docs.rs/bridgestan>`__.
 Example Program
 ---------------
 
-An example program is provided alongside the Rust crate in ``examples/example.rs``:
+An example program is provided alongside the Rust crate in :file:`examples/example.rs`:
 
 .. raw:: html
 

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -40,7 +40,7 @@ extern int bs_patch_version;
  * This PRNG is used for RNG functions in the `transformed data`
  * block of the model, and then discarded.
  * @param[out] error_msg a pointer to a string that will be allocated if there
- * is an error. This must later be freed by calling `bs_free_error_msg`.
+ * is an error. This must later be freed by calling bs_free_error_msg().
  * @return pointer to constructed model or `nullptr` if construction
  * fails
  */
@@ -161,10 +161,10 @@ int bs_param_unc_num(const bs_model* m);
  * @param[in] theta_unc sequence of unconstrained parameters
  * @param[out] theta sequence of constrained parameters
  * @param[in] rng pointer to pseudorandom number generator, should be created
- * by `bs_rng_construct`. This is only required when `include_gq` is `true`,
+ * by bs_rng_construct(). This is only required when `include_gq` is `true`,
  * otherwise it can be null.
  * @param[out] error_msg a pointer to a string that will be allocated if there
- * is an error. This must later be freed by calling `bs_free_error_msg`.
+ * is an error. This must later be freed by calling bs_free_error_msg().
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
@@ -183,7 +183,7 @@ int bs_param_constrain(const bs_model* m, bool include_tp, bool include_gq,
  * @param[in] theta sequence of constrained parameters
  * @param[out] theta_unc sequence of unconstrained parameters
  * @param[out] error_msg a pointer to a string that will be allocated if there
- * is an error. This must later be freed by calling `bs_free_error_msg`.
+ * is an error. This must later be freed by calling bs_free_error_msg().
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
@@ -200,7 +200,7 @@ int bs_param_unconstrain(const bs_model* m, const double* theta,
  * @param[in] json JSON-encoded constrained parameters
  * @param[out] theta_unc sequence of unconstrained parameters
  * @param[out] error_msg a pointer to a string that will be allocated if there
- * is an error. This must later be freed by calling `bs_free_error_msg`.
+ * is an error. This must later be freed by calling bs_free_error_msg().
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
@@ -220,7 +220,7 @@ int bs_param_unconstrain_json(const bs_model* m, const char* json,
  * @param[in] theta_unc unconstrained parameters
  * @param[out] lp log density to be set
  * @param[out] error_msg a pointer to a string that will be allocated if there
- * is an error. This must later be freed by calling `bs_free_error_msg`.
+ * is an error. This must later be freed by calling bs_free_error_msg().
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
@@ -244,7 +244,7 @@ int bs_log_density(const bs_model* m, bool propto, bool jacobian,
  * @param[out] val log density to be set
  * @param[out] grad gradient to set
  * @param[out] error_msg a pointer to a string that will be allocated if there
- * is an error. This must later be freed by calling `bs_free_error_msg`.
+ * is an error. This must later be freed by calling bs_free_error_msg().
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
@@ -272,7 +272,7 @@ int bs_log_density_gradient(const bs_model* m, bool propto, bool jacobian,
  * @param[out] grad gradient to set
  * @param[out] hessian hessian to set
  * @param[out] error_msg a pointer to a string that will be allocated if there
- * is an error. This must later be freed by calling `bs_free_error_msg`.
+ * is an error. This must later be freed by calling bs_free_error_msg().
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
@@ -281,13 +281,13 @@ int bs_log_density_hessian(const bs_model* m, bool propto, bool jacobian,
                            double* hessian, char** error_msg);
 
 /**
- * Construct an PRNG object to be used in `bs_param_constrain`.
+ * Construct an PRNG object to be used in bs_param_constrain().
  * This object is not thread safe and should be constructed and
  * destructed for each thread.
  *
  * @param[in] seed seed for the RNG
  * @param[out] error_msg a pointer to a string that will be allocated if there
- * is an error. This must later be freed by calling `bs_free_error_msg`.
+ * is an error. This must later be freed by calling bs_free_error_msg().
  */
 bs_rng* bs_rng_construct(unsigned int seed, char** error_msg);
 
@@ -307,7 +307,7 @@ void bs_rng_destruct(bs_rng* rng);
  * never propagate an exception. Passing NULL will redirect printing back to
  * stdout.
  * @param[out] error_msg a pointer to a string that will be allocated if there
- * is an error. This must later be freed by calling `bs_free_error_msg`.
+ * is an error. This must later be freed by calling bs_free_error_msg().
  * @return code 0 if successful and code -1 if there is an exception
  */
 int bs_set_print_callback(STREAM_CALLBACK callback, char** error_msg);

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -259,7 +259,7 @@ int bs_log_density_gradient(const bs_model* m, bool propto, bool jacobian,
  * `jacobian` is `true`, and return a return code of 0 for success
  * and -1 if there is an exception executing the Stan program.  The
  * pointer `grad` must have enough space to hold the gradient.  The
- * pointer `Hessian` must have enough space to hold the Hessian.
+ * pointer `hessian` must have enough space to hold the Hessian.
  *
  * The gradients are computed using automatic differentiation.  the
  * Hessians are


### PR DESCRIPTION
This tries to apply a more consistent style to the docs:

- Use more of the [Sphinx directives](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html) for things like files
- Better cross-linking of functions to each other
- I changed the highlight color for `code items` to a shade of green rather than the default pink
- I fixed up some paragraphs which were outdated or missing information