### PR TITLE
Update CI and Makefile

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,11 @@ on:
 env:
   CACHE_VERSION: 0
 
+# only run one copy per PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
This fixes CI failures caused by the recent [changes to Github Actions Runners](https://github.com/actions/runner-images/releases/tag/win22%2F20230918.1) to use Mingw 12.2.0

Something like this will hopefully be incorporated into Stan's makefiles in the future.