### PR TITLE
Pass -h/--dereference to tar in release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create tarball
         run: |
-          tar --exclude-vcs -czvf bridgestan-${{ inputs.new_version }}.tar.gz --transform 's,^,bridgestan-${{ inputs.new_version }}/,' *
+          tar --exclude-vcs -chzvf bridgestan-${{ inputs.new_version }}.tar.gz --transform 's,^,bridgestan-${{ inputs.new_version }}/,' *
 
         # Note: because of the order of operations here, the Julia package inside the tarball can never point to itself.
       - name: Update Julia artifact


### PR DESCRIPTION
A user who was using Windows without administrative permissions reported to me that BridgeStan was failing to install the C++ sources due to a permissions error. 

Some investigating showed that this was due to the symlink in `rust/src`, since [symlinks are always permission 0777](https://man7.org/linux/man-pages/man7/symlink.7.html). After some digging, I found that GNU tar supports replacing symlinks with their targets by passing `-h`/`--dereference`, and in fact [recommends doing this](https://ftp.gnu.org/old-gnu/Manuals/tar-1.12/html_node/tar_115.html):

>  So, for portable archives, do not archive symbolic links as such, and use `--dereference` (`-h`): many systems do not support symbolic links, and moreover, your distribution might be unusable if it contains unresolved symbolic links. 

Unfortunately this will only begin to take effect in the _next_ release, and we're unable to update previous releases due to the Julia artifact containing a hash of those tarfiles. 