### PR TITLE
Python: Issue warning when re-loading the same module

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -115,8 +115,8 @@ jobs:
 
       - name: Run tests
         run: |
+          pytest -v python/
           cd python/
-          pytest -v
           python example.py
         env:
           BRIDGESTAN: ${{ github.workspace }}

--- a/docs/internals/testing.rst
+++ b/docs/internals/testing.rst
@@ -33,15 +33,13 @@ Running
 
 .. code-block:: shell
 
-    cd python/
-    pytest -v
+    pytest -v python/
 
 Will run the "default" grouping. To run the other group(s), run
 
 .. code-block:: shell
 
-    cd python/
-    pytest --run-type=ad_hessian -v
+    pytest --run-type=ad_hessian -v python/
 
 The set up for this can be seen in :file:`tests/conftest.py` and is based on the
 `Pytest documentation examples <https://docs.pytest.org/en/7.1.x/example/simple.html#control-skipping-of-tests-according-to-command-line-option>`__.

--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -1,13 +1,15 @@
 import ctypes
 import warnings
+from pathlib import Path
 from typing import List, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
+from dllist import dllist
 from numpy.ctypeslib import ndpointer
 
 from .__version import __version_info__
-from .compile import windows_dll_path_setup, compile_model
+from .compile import compile_model, windows_dll_path_setup
 from .util import validate_readable
 
 FloatArray = npt.NDArray[np.float64]
@@ -68,7 +70,12 @@ class StanModel:
                 model_data = f.read()
 
         windows_dll_path_setup()
-        self.lib_path = model_lib
+        self.lib_path = str(Path(model_lib).absolute().resolve())
+        if self.lib_path in dllist():
+            warnings.warn(
+                f"Loading a shared object {self.lib_path} that has already been loaded.\n"
+                "If the file has changed since the last time it was loaded, this load may not update the library!"
+            )
         self.stanlib = ctypes.CDLL(self.lib_path)
 
         self.data = model_data or ""

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "Edward Roualdes", email = "eroualdes@csuchico.edu" },
 ]
 requires-python = ">=3.9"
-dependencies = ["numpy"]
+dependencies = ["numpy", "dllist"]
 dynamic = ["version"]
 
 [tool.setuptools.dynamic]

--- a/python/test/test_stanmodel.py
+++ b/python/test/test_stanmodel.py
@@ -9,7 +9,6 @@ STAN_FOLDER = Path(__file__).parent.parent.parent / "test_models"
 
 
 def test_constructor():
-
     # implicit destructor tests in success and fail cases
 
     # test empty data
@@ -595,7 +594,6 @@ def test_multi():
 
 
 def test_gaussian():
-
     lib = str(STAN_FOLDER / "gaussian" / "gaussian_model.so")
     data = str(STAN_FOLDER / "gaussian" / "gaussian.data.json")
 
@@ -616,7 +614,6 @@ def test_gaussian():
 
 
 def test_fr_gaussian():
-
     lib = str(STAN_FOLDER / "fr_gaussian" / "fr_gaussian_model.so")
     data = str(STAN_FOLDER / "fr_gaussian" / "fr_gaussian.data.json")
     model = bs.StanModel(lib, data)
@@ -708,6 +705,17 @@ def test_stdout_capture():
 
     assert x == 500  # 2 calls per print, 10 threads, 25 iterations
 
+
+def test_reload_warning():
+    lib = STAN_FOLDER / "fr_gaussian" / "fr_gaussian_model.so"
+    data = str(STAN_FOLDER / "fr_gaussian" / "fr_gaussian.data.json")
+    model = bs.StanModel(str(lib), data)
+
+
+    relative_lib = lib.relative_to(STAN_FOLDER.parent)
+    assert not relative_lib.is_absolute()
+    with pytest.warns(UserWarning, match="may not update the library"):
+        model2 = bs.StanModel(str(relative_lib), data)
 
 @pytest.fixture(scope="module")
 def recompile_simple():


### PR DESCRIPTION
@charlesm93 recently ran into the issue where re-loading the same shared library is a no-op on some systems. 

We warn against this in Julia and R (#45), but in Python the standard library was missing a way to list all already-loaded dlls, so it was left out.

After Charles' prompting, I wrote one: https://github.com/WardBrian/dllist
This small Python package essentially re-implements the same platform-specific logic that the Julia `dllist` function that we use does. I finished it up this morning and put it on PyPI, so if we don't mind a small extra dependency we can add this warning now for Python users as well.