### PR TITLE
Fix memory leak in log_density(propto=True)

### DIFF
--- a/src/model_rng.cpp
+++ b/src/model_rng.cpp
@@ -263,6 +263,7 @@ void bs_model::log_density(bool propto, bool jacobian, const double* theta_unc,
     } else {
       *val = model_->log_prob_propto(params_unc_var, outstream).val();
     }
+    stan::math::recover_memory();
   } else {
     if (jacobian) {
       *val = model_->log_prob_jacobian(params_unc, outstream);

--- a/src/model_rng.cpp
+++ b/src/model_rng.cpp
@@ -256,13 +256,21 @@ void bs_model::log_density(bool propto, bool jacobian, const double* theta_unc,
   if (propto) {
     // need to have vars, otherwise the result is 0 since everything is
     // treated as a constant
-    Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> params_unc_var(
-        params_unc);
-    if (jacobian) {
-      *val = model_->log_prob_propto_jacobian(params_unc_var, outstream).val();
-    } else {
-      *val = model_->log_prob_propto(params_unc_var, outstream).val();
+    try {
+      Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> params_unc_var(
+          params_unc);
+      if (jacobian) {
+        *val
+            = model_->log_prob_propto_jacobian(params_unc_var, outstream).val();
+      } else {
+        *val = model_->log_prob_propto(params_unc_var, outstream).val();
+      }
+    } catch (...) {
+      // because we created vars on the stack, we need to recover memory
+      stan::math::recover_memory();
+      throw;  // re-caught by top level exception logic
     }
+    // also recover memory if no exception was thrown
     stan::math::recover_memory();
   } else {
     if (jacobian) {


### PR DESCRIPTION
When I submitted #165 to fix the unnecessary computation in `log_density(propto=True)` I didn't consider that removing the call to `grad` also meant the `var` stack was no longer being cleared, so the memory would build up over time.

You can see this pretty easily in the current version, e.g.:

```python
import numpy as np
import bridgestan

m = bridgestan.StanModel("./test_models/gaussian/gaussian_model.so", "./test_models/gaussian/gaussian.data.json")

def print_lp():
    p = np.random.randn(2)
    lp = m.log_density(p, propto=True)
    print(lp)

for _ in range(100_000):
    print_lp()
```

Running this in a repl, you can see that the memory used by the process grows throughout the loop and stays high. After this PR, it does not. 