### PR TITLE
Update stanc to version 2.33.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ print-%  : ; @echo $* = $($*) ;
 STANC_DL_RETRY = 5
 STANC_DL_DELAY = 10
 STANC3_TEST_BIN_URL ?=
-STANC3_VERSION ?= v2.33.0
+STANC3_VERSION ?= v2.33.1
 
 ifeq ($(OS),Windows_NT)
  OS_TAG := windows

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Stan is a probabilistic programming language for coding statistical
 models.  For an introduction to what can be coded in Stan, see the
 [*Stan User's Guide*](https://mc-stan.org/docs/stan-users-guide/index.html).
 
-BridgeStan is currently shipping with Stan version 2.33.0
+BridgeStan is currently shipping with Stan version 2.33.1
 
 Documentation is available at https://roualdes.github.io/bridgestan/
 


### PR DESCRIPTION
The Stan submodule has no changes, so this wasn't picked up automatically. The [only changes](https://github.com/stan-dev/stanc3/releases/tag/v2.33.1) in 2.33.1 were in the compiler code generation for tuples.