### PR TITLE
Set up visibility controls for public symbols in the library

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
 
 # only run one copy per PR
 concurrency:

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ include $(MATH)make/compiler_flags
 include $(MATH)make/libraries
 
 ## Set -fPIC globally since we're always building a shared library
-CXXFLAGS += -fPIC
+CXXFLAGS += -fPIC -fvisibility=hidden -fvisibility-inlines-hidden
 CXXFLAGS_SUNDIALS += -fPIC
+CPPFLAGS += -DBRIDGESTAN_EXPORT
 
 ## set flags for stanc compiler (math calls MIGHT? set STAN_OPENCL)
 ifdef STAN_OPENCL
@@ -34,7 +35,7 @@ else
 	STAN_FLAG_THREADS=
 endif
 ifdef BRIDGESTAN_AD_HESSIAN
-	CXXFLAGS+=-DSTAN_MODEL_FVAR_VAR -DBRIDGESTAN_AD_HESSIAN
+	CPPFLAGS += -DSTAN_MODEL_FVAR_VAR -DBRIDGESTAN_AD_HESSIAN
 	STAN_FLAG_HESS=_adhessian
 else
 	STAN_FLAG_HESS=
@@ -65,7 +66,6 @@ $(BRIDGE_O) : $(BRIDGE_DEPS)
 	@echo ''
 	@echo '--- Linking C++ code ---'
 	$(LINK.cpp) -shared -lm -o $(patsubst %.o, %_model.so, $(subst \,/,$<)) $(subst \,/,$*.o) $(BRIDGE_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)
-	$(RM) $(subst  \,/,$*).o
 
 .PHONY: docs
 docs:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,13 +18,13 @@ import os
 import bridgestan
 
 version = os.getenv("BS_DOCS_VERSION", bridgestan.__version__)
-if version == "latest" :
+if version == "latest":
     # don't display a version number for "latest" docs
     switcher_version = "latest"
     release = ""
 else:
     release = version
-    switcher_version = f'v{version}'
+    switcher_version = f"v{version}"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -100,8 +100,16 @@ intersphinx_mapping = {
 breathe_projects = {"bridgestan": "./_build/cppxml/"}
 breathe_projects_source = {"bridgestan": ("../src/", ["bridgestan.h", "bridgestanR.h"])}
 breathe_default_project = "bridgestan"
+# doxygen doesn't like  __attribute and __declspec
+# https://www.doxygen.nl/manual/preprocessing.html
+breathe_doxygen_config_options = {
+    "ENABLE_PREPROCESSING": "YES",
+    "MACRO_EXPANSION": "YES",
+    "EXPAND_ONLY_PREDEF": "YES",
+    "PREDEFINED": "BS_PUBLIC=",
+}
 
-autoclass_content = 'both'
+autoclass_content = "both"
 
 # Julia and C++ doc build
 import os

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -17,15 +17,26 @@ typedef struct bs_rng bs_rng;      ///< Opaque type for RNG
 typedef void (*STREAM_CALLBACK)(const char* data, size_t size);
 #endif
 
+// Macros to control visibility of symbols in the shared library.
+#if defined _WIN32 || defined __MINGW32__
+#ifdef BRIDGESTAN_EXPORT
+#define BS_PUBLIC __declspec(dllexport)
+#else
+#define BS_PUBLIC __declspec(dllimport)
+#endif
+#else
+#define BS_PUBLIC __attribute__((visibility("default")))
+#endif
+
 /**
  * Version information for the BridgeStan library.
  * @note These are *not* the version of the wrapped Stan library.
  * @note These were not available pre-2.0.0, so their absence
  * implies the library is in the 1.0.x series
  */
-extern int bs_major_version;
-extern int bs_minor_version;
-extern int bs_patch_version;
+BS_PUBLIC extern int bs_major_version;
+BS_PUBLIC extern int bs_minor_version;
+BS_PUBLIC extern int bs_patch_version;
 
 /**
  * Construct an instance of a model wrapper.
@@ -44,22 +55,22 @@ extern int bs_patch_version;
  * @return pointer to constructed model or `nullptr` if construction
  * fails
  */
-bs_model* bs_model_construct(const char* data, unsigned int seed,
-                             char** error_msg);
+BS_PUBLIC bs_model* bs_model_construct(const char* data, unsigned int seed,
+                                       char** error_msg);
 
 /**
  * Destroy the model.
  *
  * @param[in] m pointer to model structure
  */
-void bs_model_destruct(bs_model* m);
+BS_PUBLIC void bs_model_destruct(bs_model* m);
 
 /**
  * Free the error messages created by other methods.
  *
  * @param[in] error_msg pointer to error message
  */
-void bs_free_error_msg(char* error_msg);
+BS_PUBLIC void bs_free_error_msg(char* error_msg);
 
 /**
  * Return the name of the specified model as a C-style string.
@@ -70,7 +81,7 @@ void bs_free_error_msg(char* error_msg);
  * @param[in] m pointer to model and RNG structure
  * @return name of model
  */
-const char* bs_name(const bs_model* m);
+BS_PUBLIC const char* bs_name(const bs_model* m);
 
 /**
  * Return information about the compiled model as a C-style string.
@@ -82,7 +93,7 @@ const char* bs_name(const bs_model* m);
  * @return Information about the model including Stan version, Stan defines, and
  * compiler flags.
  */
-const char* bs_model_info(const bs_model* m);
+BS_PUBLIC const char* bs_model_info(const bs_model* m);
 
 /**
  * Return a comma-separated sequence of indexed parameter names,
@@ -103,7 +114,8 @@ const char* bs_model_info(const bs_model* m);
  * @param[in] include_gq `true` to include generated quantities
  * @return CSV-separated, indexed, parameter names
  */
-const char* bs_param_names(const bs_model* m, bool include_tp, bool include_gq);
+BS_PUBLIC const char* bs_param_names(const bs_model* m, bool include_tp,
+                                     bool include_gq);
 
 /**
  * Return a comma-separated sequence of unconstrained parameters.
@@ -122,7 +134,7 @@ const char* bs_param_names(const bs_model* m, bool include_tp, bool include_gq);
  * @param[in] m pointer to model structure
  * @return CSV-separated, indexed, unconstrained parameter names
  */
-const char* bs_param_unc_names(const bs_model* m);
+BS_PUBLIC const char* bs_param_unc_names(const bs_model* m);
 
 /**
  * Return the number of scalar parameters, optionally including the
@@ -134,7 +146,7 @@ const char* bs_param_unc_names(const bs_model* m);
  * @param[in] include_gq `true` to include generated quantities
  * @return number of parameters
  */
-int bs_param_num(const bs_model* m, bool include_tp, bool include_gq);
+BS_PUBLIC int bs_param_num(const bs_model* m, bool include_tp, bool include_gq);
 
 /**
  * Return the number of unconstrained parameters.  The number of
@@ -145,7 +157,7 @@ int bs_param_num(const bs_model* m, bool include_tp, bool include_gq);
  * @param[in] m pointer to model structure
  * @return number of unconstrained parameters
  */
-int bs_param_unc_num(const bs_model* m);
+BS_PUBLIC int bs_param_unc_num(const bs_model* m);
 
 /**
  * Set the sequence of constrained parameters based on the specified
@@ -168,9 +180,9 @@ int bs_param_unc_num(const bs_model* m);
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_param_constrain(const bs_model* m, bool include_tp, bool include_gq,
-                       const double* theta_unc, double* theta, bs_rng* rng,
-                       char** error_msg);
+BS_PUBLIC int bs_param_constrain(const bs_model* m, bool include_tp,
+                                 bool include_gq, const double* theta_unc,
+                                 double* theta, bs_rng* rng, char** error_msg);
 
 /**
  * Set the sequence of unconstrained parameters based on the
@@ -187,8 +199,8 @@ int bs_param_constrain(const bs_model* m, bool include_tp, bool include_gq,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_param_unconstrain(const bs_model* m, const double* theta,
-                         double* theta_unc, char** error_msg);
+BS_PUBLIC int bs_param_unconstrain(const bs_model* m, const double* theta,
+                                   double* theta_unc, char** error_msg);
 
 /**
  * Set the sequence of unconstrained parameters based on the JSON
@@ -204,8 +216,8 @@ int bs_param_unconstrain(const bs_model* m, const double* theta,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_param_unconstrain_json(const bs_model* m, const char* json,
-                              double* theta_unc, char** error_msg);
+BS_PUBLIC int bs_param_unconstrain_json(const bs_model* m, const char* json,
+                                        double* theta_unc, char** error_msg);
 
 /**
  * Set the log density of the specified parameters, dropping
@@ -224,8 +236,9 @@ int bs_param_unconstrain_json(const bs_model* m, const char* json,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_log_density(const bs_model* m, bool propto, bool jacobian,
-                   const double* theta_unc, double* lp, char** error_msg);
+BS_PUBLIC int bs_log_density(const bs_model* m, bool propto, bool jacobian,
+                             const double* theta_unc, double* lp,
+                             char** error_msg);
 
 /**
  * Set the log density and gradient of the specified parameters,
@@ -248,9 +261,10 @@ int bs_log_density(const bs_model* m, bool propto, bool jacobian,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_log_density_gradient(const bs_model* m, bool propto, bool jacobian,
-                            const double* theta_unc, double* val, double* grad,
-                            char** error_msg);
+BS_PUBLIC int bs_log_density_gradient(const bs_model* m, bool propto,
+                                      bool jacobian, const double* theta_unc,
+                                      double* val, double* grad,
+                                      char** error_msg);
 
 /**
  * Set the log density, gradient, and Hessian of the specified parameters,
@@ -279,9 +293,10 @@ int bs_log_density_gradient(const bs_model* m, bool propto, bool jacobian,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_log_density_hessian(const bs_model* m, bool propto, bool jacobian,
-                           const double* theta_unc, double* val, double* grad,
-                           double* hessian, char** error_msg);
+BS_PUBLIC int bs_log_density_hessian(const bs_model* m, bool propto,
+                                     bool jacobian, const double* theta_unc,
+                                     double* val, double* grad, double* hessian,
+                                     char** error_msg);
 
 /**
  * Calculate the log density and the product of the Hessian with the specified
@@ -313,11 +328,9 @@ int bs_log_density_hessian(const bs_model* m, bool propto, bool jacobian,
  * @return code 0 if successful and code -1 if there is an exception
  * in the underlying Stan code
  */
-int bs_log_density_hessian_vector_product(const bs_model* m, bool propto,
-                                          bool jacobian,
-                                          const double* theta_unc,
-                                          const double* vector, double* val,
-                                          double* hvp, char** error_msg);
+BS_PUBLIC int bs_log_density_hessian_vector_product(
+    const bs_model* m, bool propto, bool jacobian, const double* theta_unc,
+    const double* vector, double* val, double* hvp, char** error_msg);
 
 /**
  * Construct an PRNG object to be used in bs_param_constrain().
@@ -328,14 +341,14 @@ int bs_log_density_hessian_vector_product(const bs_model* m, bool propto,
  * @param[out] error_msg a pointer to a string that will be allocated if there
  * is an error. This must later be freed by calling bs_free_error_msg().
  */
-bs_rng* bs_rng_construct(unsigned int seed, char** error_msg);
+BS_PUBLIC bs_rng* bs_rng_construct(unsigned int seed, char** error_msg);
 
 /**
  * Destruct an RNG object.
  *
  * @param[in] rng pointer to RNG object
  */
-void bs_rng_destruct(bs_rng* rng);
+BS_PUBLIC void bs_rng_destruct(bs_rng* rng);
 
 /**
  * Provide a function for printing. This will be called when the Stan
@@ -349,7 +362,7 @@ void bs_rng_destruct(bs_rng* rng);
  * is an error. This must later be freed by calling bs_free_error_msg().
  * @return code 0 if successful and code -1 if there is an exception
  */
-int bs_set_print_callback(STREAM_CALLBACK callback, char** error_msg);
+BS_PUBLIC int bs_set_print_callback(STREAM_CALLBACK callback, char** error_msg);
 
 #ifdef __cplusplus
 }

--- a/src/bridgestanR.h
+++ b/src/bridgestanR.h
@@ -1,28 +1,26 @@
 #ifndef BRIDGESTANR_H
 #define BRIDGESTANR_H
 
+#include "bridgestan.h"
+
 /// \file bridgestanR.h
 
 #ifdef __cplusplus
-#include "model_rng.hpp"
 extern "C" {
-#else
-typedef struct bs_model bs_model;
-typedef struct bs_rng bs_rng;
-typedef int bool;
 #endif
 
 // Shim to convert to R interface requirement of void with pointer args
 // All calls directly delegated to versions without _R suffix
+
 /// See \link bs_model_construct() \endlink for more details.
-void bs_model_construct_R(char** data, int* rng, bs_model** ptr_out,
-                          char** err_msg, void** err_ptr);
+BS_PUBLIC void bs_model_construct_R(char** data, int* rng, bs_model** ptr_out,
+                                    char** err_msg, void** err_ptr);
 
 /// See \link bs_major_version \endlink for more details.
-void bs_version_R(int* major, int* minor, int* patch);
+BS_PUBLIC void bs_version_R(int* major, int* minor, int* patch);
 
 /// See \link bs_model_destruct() \endlink for more details.
-void bs_model_destruct_R(bs_model** model);
+BS_PUBLIC void bs_model_destruct_R(bs_model** model);
 
 /**
  * Free error message allocated in C++. Because R performs copies
@@ -30,74 +28,77 @@ void bs_model_destruct_R(bs_model** model);
  *
  * See \link bs_free_error_msg() \endlink for more details.
  */
-void bs_free_error_msg_R(void** err_msg);
+BS_PUBLIC void bs_free_error_msg_R(void** err_msg);
 
 /// See \link bs_name() \endlink for more details.
-void bs_name_R(bs_model** model, char const** name_out);
+BS_PUBLIC void bs_name_R(bs_model** model, char const** name_out);
 
 /// See \link bs_model_info() \endlink for more details.
-void bs_model_info_R(bs_model** model, char const** info_out);
+BS_PUBLIC void bs_model_info_R(bs_model** model, char const** info_out);
 
 /// See \link bs_param_names() \endlink for more details.
-void bs_param_names_R(bs_model** model, int* include_tp, int* include_gq,
-                      char const** name_out);
+BS_PUBLIC void bs_param_names_R(bs_model** model, int* include_tp,
+                                int* include_gq, char const** name_out);
 
 /// See \link bs_param_unc_names() \endlink for more details.
-void bs_param_unc_names_R(bs_model** model, char const** name_out);
+BS_PUBLIC void bs_param_unc_names_R(bs_model** model, char const** name_out);
 
 /// See \link bs_param_num() \endlink for more details.
-void bs_param_num_R(bs_model** model, int* include_tp, int* include_gq,
-                    int* num_out);
+BS_PUBLIC void bs_param_num_R(bs_model** model, int* include_tp,
+                              int* include_gq, int* num_out);
 
 /// See \link bs_param_unc_num() \endlink for more details.
-void bs_param_unc_num_R(bs_model** model, int* num_out);
+BS_PUBLIC void bs_param_unc_num_R(bs_model** model, int* num_out);
 
 /// See \link bs_param_constrain() \endlink for more details.
-void bs_param_constrain_R(bs_model** model, int* include_tp, int* include_gq,
-                          const double* theta_unc, double* theta, bs_rng** rng,
-                          int* return_code, char** err_msg, void** err_ptr);
+BS_PUBLIC void bs_param_constrain_R(bs_model** model, int* include_tp,
+                                    int* include_gq, const double* theta_unc,
+                                    double* theta, bs_rng** rng,
+                                    int* return_code, char** err_msg,
+                                    void** err_ptr);
 
 /// See \link bs_param_unconstrain() \endlink for more details.
-void bs_param_unconstrain_R(bs_model** model, const double* theta,
-                            double* theta_unc, int* return_code, char** err_msg,
-                            void** err_ptr);
+BS_PUBLIC void bs_param_unconstrain_R(bs_model** model, const double* theta,
+                                      double* theta_unc, int* return_code,
+                                      char** err_msg, void** err_ptr);
 
 /// See \link bs_param_unconstrain_json() \endlink for more details.
-void bs_param_unconstrain_json_R(bs_model** model, char const** json,
-                                 double* theta_unc, int* return_code,
-                                 char** err_msg, void** err_ptr);
+BS_PUBLIC void bs_param_unconstrain_json_R(bs_model** model, char const** json,
+                                           double* theta_unc, int* return_code,
+                                           char** err_msg, void** err_ptr);
 
 /// See \link bs_log_density() \endlink for more details.
-void bs_log_density_R(bs_model** model, int* propto, int* jacobian,
-                      const double* theta_unc, double* val, int* return_code,
-                      char** err_msg, void** err_ptr);
+BS_PUBLIC void bs_log_density_R(bs_model** model, int* propto, int* jacobian,
+                                const double* theta_unc, double* val,
+                                int* return_code, char** err_msg,
+                                void** err_ptr);
 
 /// See \link bs_log_density_gradient() \endlink for more details.
-void bs_log_density_gradient_R(bs_model** model, int* propto, int* jacobian,
-                               const double* theta_unc, double* val,
-                               double* grad, int* return_code, char** err_msg,
-                               void** err_ptr);
+BS_PUBLIC void bs_log_density_gradient_R(bs_model** model, int* propto,
+                                         int* jacobian, const double* theta_unc,
+                                         double* val, double* grad,
+                                         int* return_code, char** err_msg,
+                                         void** err_ptr);
 
 /// See \link bs_log_density_hessian() \endlink for more details.
-void bs_log_density_hessian_R(bs_model** model, int* propto, int* jacobian,
-                              const double* theta_unc, double* val,
-                              double* grad, double* hess, int* return_code,
-                              char** err_msg, void** err_ptr);
+BS_PUBLIC void bs_log_density_hessian_R(bs_model** model, int* propto,
+                                        int* jacobian, const double* theta_unc,
+                                        double* val, double* grad, double* hess,
+                                        int* return_code, char** err_msg,
+                                        void** err_ptr);
 
 /// See \link bs_log_density_hessian_vector_product() \endlink for more details.
-void bs_log_density_hessian_vector_product_R(bs_model** model, int* propto,
-                                             int* jacobian,
-                                             const double* theta_unc,
-                                             const double* vector, double* val,
-                                             double* Hvp, int* return_code,
-                                             char** err_msg, void** err_ptr);
+BS_PUBLIC void bs_log_density_hessian_vector_product_R(
+    bs_model** model, int* propto, int* jacobian, const double* theta_unc,
+    const double* vector, double* val, double* Hvp, int* return_code,
+    char** err_msg, void** err_ptr);
 
 /// See \link bs_rng_construct() \endlink for more details.
-void bs_rng_construct_R(int* seed, bs_rng** ptr_out, char** err_msg,
-                        void** err_ptr);
+BS_PUBLIC void bs_rng_construct_R(int* seed, bs_rng** ptr_out, char** err_msg,
+                                  void** err_ptr);
 
 /// See \link bs_rng_destruct() \endlink for more details.
-void bs_rng_destruct_R(bs_rng** rng);
+BS_PUBLIC void bs_rng_destruct_R(bs_rng** rng);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR makes the necessary changes to set the default symbol visibility to "hidden". It's worth reading more about this on the [GCC Wiki](https://gcc.gnu.org/wiki/Visibility).

The summary:
- By default, every symbol in a shared library is available to the linker
- If you are explicit about which symbols _actually should be public_, your compiler can then perform optimizations based on the assumption that the remaining code doesn't need to be accessible
- The Microsoft compilers do this by default, with the added wrinkle of also distinguishing between "public and provided by the current translation unit" (`dllexport`) vs "public and provided by someone else" (`dllimport`)