### PR TITLE
Unify constructors to always allow a .stan file to be passed

### DIFF
--- a/R/example.R
+++ b/R/example.R
@@ -1,10 +1,8 @@
-# Before running this:
-#  - In the terminal, run `make test_models/bernoulli/bernoulli_model.so` from inside the bridgestan folder
-#  - In R, make sure you are in the directory bridgestan/R
+# Before running this, make sure you are in the directory bridgestan/R
 
 library(bridgestan)
 
-model <- StanModel$new("../test_models/bernoulli/bernoulli_model.so", "../test_models/bernoulli/bernoulli.data.json", 1234)
+model <- StanModel$new("../test_models/bernoulli/bernoulli.stan", "../test_models/bernoulli/bernoulli.data.json", 1234)
 
 print(paste0("This model's name is ", model$name(), "."))
 print(paste0("This model has ", model$param_num(), " parameters."))

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -116,27 +116,19 @@ An example program is provided alongside the Julia interface code in `example.jl
 
 
 ```julia
-StanModel(lib, datafile="", seed=204)
+StanModel(lib, data="", seed=204; stanc_args=[], make_args=[])
 ```
 
 A StanModel instance encapsulates a Stan model instantiated with data.
 
-Construct a Stan model from the supplied library file path and data. Data should either be a string containing a JSON string literal, a path to a data file ending in `.json`, or the empty string. If seed is supplied, it is used to initialize the RNG used by the model's constructor.
+Construct a Stan model from the supplied library file path and data. If lib is a path to a file ending in `.stan`, this will first compile the model.  Compilation occurs if no shared object file exists for the supplied Stan file or if a shared object file exists and the Stan file has changed since last compilation.  This is equivalent to calling `compile_model` and then the constructor of `StanModel`.
 
-```
-StanModel(;stan_file, data="", seed=204)
-```
+Data should either be a string containing a JSON string literal, a path to a data file ending in `.json`, or the empty string.
 
-Construct a `StanModel` instance from a `.stan` file, compiling if necessary.
-
-```
-StanModel(;stan_file, stanc_args=[], make_args=[], data="", seed=204)
-```
-
-Construct a `StanModel` instance from a `.stan` file.  Compilation occurs if no shared object file exists for the supplied Stan file or if a shared object file exists and the Stan file has changed since last compilation.  This is equivalent to calling `compile_model` and then the original constructor of `StanModel`.
+If seed is supplied, it is used to initialize the RNG used by the model's constructor.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L15-L36' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L15-L31' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density' href='#BridgeStan.log_density'>#</a>
 **`BridgeStan.log_density`** &mdash; *Function*.
@@ -152,7 +144,7 @@ Return the log density of the specified unconstrained parameters.
 This calculation drops constant terms that do not depend on the parameters if `propto` is `true` and includes change of variables terms for constrained parameters if `jacobian` is `true`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L492-L499' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L497-L504' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient' href='#BridgeStan.log_density_gradient'>#</a>
 **`BridgeStan.log_density_gradient`** &mdash; *Function*.
@@ -170,7 +162,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L575-L587' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L580-L592' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian' href='#BridgeStan.log_density_hessian'>#</a>
 **`BridgeStan.log_density_hessian`** &mdash; *Function*.
@@ -188,7 +180,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the gradient and Hessian output each call. See `log_density_gradient!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L662-L673' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L667-L678' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian_vector_product' href='#BridgeStan.log_density_hessian_vector_product'>#</a>
 **`BridgeStan.log_density_hessian_vector_product`** &mdash; *Function*.
@@ -206,7 +198,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 This allocates new memory for the output each call. See `log_density_hessian_vector_product!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L744-L755' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L749-L760' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain' href='#BridgeStan.param_constrain'>#</a>
 **`BridgeStan.param_constrain`** &mdash; *Function*.
@@ -226,7 +218,7 @@ This allocates new memory for the output each call. See `param_constrain!` for a
 This is the inverse of `param_unconstrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L349-L364' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L354-L369' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain' href='#BridgeStan.param_unconstrain'>#</a>
 **`BridgeStan.param_unconstrain`** &mdash; *Function*.
@@ -246,7 +238,7 @@ This allocates new memory for the output each call. See `param_unconstrain!` for
 This is the inverse of `param_constrain`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L421-L434' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L426-L439' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json' href='#BridgeStan.param_unconstrain_json'>#</a>
 **`BridgeStan.param_unconstrain_json`** &mdash; *Function*.
@@ -264,7 +256,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 This allocates new memory for the output each call. See `param_unconstrain_json!` for a version which allows re-using existing memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L476-L486' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L481-L491' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.name' href='#BridgeStan.name'>#</a>
 **`BridgeStan.name`** &mdash; *Function*.
@@ -278,7 +270,7 @@ name(sm)
 Return the name of the model `sm`
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L155-L159' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L160-L164' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.model_info' href='#BridgeStan.model_info'>#</a>
 **`BridgeStan.model_info`** &mdash; *Function*.
@@ -294,7 +286,7 @@ Return information about the model `sm`.
 This includes the Stan version and important compiler flags.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L170-L177' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L175-L182' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_num' href='#BridgeStan.param_num'>#</a>
 **`BridgeStan.param_num`** &mdash; *Function*.
@@ -310,7 +302,7 @@ Return the number of (constrained) parameters in the model.
 This is the total of all the sizes of items declared in the `parameters` block of the model. If `include_tp` or `include_gq` are true, items declared in the `transformed parameters` and `generate quantities` blocks are included, respectively.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L200-L209' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L205-L214' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_num' href='#BridgeStan.param_unc_num'>#</a>
 **`BridgeStan.param_unc_num`** &mdash; *Function*.
@@ -326,7 +318,7 @@ Return the number of unconstrained parameters in the model.
 This function is mainly different from `param_num` when variables are declared with constraints. For example, `simplex[5]` has a constrained size of 5, but an unconstrained size of 4.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L222-L230' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L227-L235' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_names' href='#BridgeStan.param_names'>#</a>
 **`BridgeStan.param_names`** &mdash; *Function*.
@@ -344,7 +336,7 @@ For containers, indexes are separated by periods (.).
 For example, the scalar `a` has indexed name `"a"`, the vector entry `a[1]` has indexed name `"a.1"` and the matrix entry `a[2, 3]` has indexed names `"a.2.3"`. Parameter order of the output is column major and more generally last-index major for containers.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L240-L251' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L245-L256' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unc_names' href='#BridgeStan.param_unc_names'>#</a>
 **`BridgeStan.param_unc_names`** &mdash; *Function*.
@@ -360,7 +352,7 @@ Return the indexed names of the unconstrained parameters.
 For example, a scalar unconstrained parameter `b` has indexed name `b` and a vector entry `b[3]` has indexed name `b.3`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L264-L271' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L269-L276' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_gradient!' href='#BridgeStan.log_density_gradient!'>#</a>
 **`BridgeStan.log_density_gradient!`** &mdash; *Function*.
@@ -378,7 +370,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out`, and a reference is returned. See `log_density_gradient` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L521-L531' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L526-L536' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian!' href='#BridgeStan.log_density_hessian!'>#</a>
 **`BridgeStan.log_density_hessian!`** &mdash; *Function*.
@@ -396,7 +388,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The gradient is stored in the vector `out_grad` and the Hessian is stored in `out_hess` and references are returned. See `log_density_hessian` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L598-L609' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L603-L614' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.log_density_hessian_vector_product!' href='#BridgeStan.log_density_hessian_vector_product!'>#</a>
 **`BridgeStan.log_density_hessian_vector_product!`** &mdash; *Function*.
@@ -414,7 +406,7 @@ This calculation drops constant terms that do not depend on the parameters if `p
 The product is stored in the vector `out` and a reference is returned. See `log_density_hessian_vector_product` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L686-L697' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L691-L702' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_constrain!' href='#BridgeStan.param_constrain!'>#</a>
 **`BridgeStan.param_constrain!`** &mdash; *Function*.
@@ -434,7 +426,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_unconstrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L282-L296' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L287-L301' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain!' href='#BridgeStan.param_unconstrain!'>#</a>
 **`BridgeStan.param_unconstrain!`** &mdash; *Function*.
@@ -454,7 +446,7 @@ The result is stored in the vector `out`, and a reference is returned. See `para
 This is the inverse of `param_constrain!`.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L383-L395' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L388-L400' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.param_unconstrain_json!' href='#BridgeStan.param_unconstrain_json!'>#</a>
 **`BridgeStan.param_unconstrain_json!`** &mdash; *Function*.
@@ -472,7 +464,7 @@ The JSON is expected to be in the [JSON Format for CmdStan](https://mc-stan.org/
 The result is stored in the vector `out`, and a reference is returned. See `param_unconstrain_json` for a version which allocates fresh memory.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L440-L449' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L445-L454' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.StanRNG' href='#BridgeStan.StanRNG'>#</a>
 **`BridgeStan.StanRNG`** &mdash; *Type*.
@@ -490,7 +482,7 @@ This can be used in the `param_constrain` and `param_constrain!` methods when us
 This object is not thread-safe, one should be created per thread.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L97-L106' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L102-L111' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.new_rng' href='#BridgeStan.new_rng'>#</a>
 **`BridgeStan.new_rng`** &mdash; *Function*.
@@ -508,7 +500,7 @@ This can be used in the `param_constrain` and `param_constrain!` methods when us
 The StanRNG object created is not thread-safe, one should be created per thread.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L142-L152' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/model.jl#L147-L157' class='documenter-source'>source</a><br>
 
 
 <a id='Compilation-utilities'></a>

--- a/julia/example.jl
+++ b/julia/example.jl
@@ -11,7 +11,7 @@ BS.set_bridgestan_path!("../")
 bernoulli_stan = joinpath(@__DIR__, "../test_models/bernoulli/bernoulli.stan")
 bernoulli_data = joinpath(@__DIR__, "../test_models/bernoulli/bernoulli.data.json")
 
-smb = BS.StanModel(stan_file = bernoulli_stan, data = bernoulli_data);
+smb = BS.StanModel(bernoulli_stan, bernoulli_data);
 
 println("This model's name is $(BS.name(smb)).")
 println("It has $(BS.param_num(smb)) parameters.")

--- a/julia/src/BridgeStan.jl
+++ b/julia/src/BridgeStan.jl
@@ -34,7 +34,7 @@ include("compile.jl")
 """
     StanModel(;stan_file, stanc_args=[], make_args=[], data="", seed=204)
 
-Deprecated; use the normal constructor, StanModel(...) instead.
+Deprecated; use the normal constructor, StanModel(...), with a path to a `.stan` file, instead.
 
 Construct a StanModel instance from a `.stan` file, compiling if necessary.
 This is equivalent to calling `compile_model` and then the original constructor of StanModel.

--- a/julia/src/BridgeStan.jl
+++ b/julia/src/BridgeStan.jl
@@ -34,17 +34,24 @@ include("compile.jl")
 """
     StanModel(;stan_file, stanc_args=[], make_args=[], data="", seed=204)
 
-Construct a StanModel instance from a `.stan` file, compiling if necessary.
+Deprecated; use the normal constructor, StanModel(...) instead.
 
+Construct a StanModel instance from a `.stan` file, compiling if necessary.
 This is equivalent to calling `compile_model` and then the original constructor of StanModel.
 """
-StanModel(;
+function StanModel(;
     stan_file::String,
     stanc_args::AbstractVector{String} = String[],
     make_args::AbstractVector{String} = String[],
     data::String = "",
     seed = 204,
-) = StanModel(compile_model(stan_file; stanc_args, make_args), data, seed)
+)
+    Base.depwarn(
+        "StanModel(;stan_file,... ) is deprecated. Use the normal constructor, StanModel(...) instead.",
+        :StanModel,
+    )
+    StanModel(stan_file, data, seed; stanc_args, make_args)
+end
 
 
 function __init__()

--- a/julia/test/compile_tests.jl
+++ b/julia/test/compile_tests.jl
@@ -13,9 +13,15 @@ models = joinpath(BridgeStan.get_bridgestan_path(), "test_models/")
     res = BridgeStan.compile_model(stanfile; stanc_args = ["--O1"])
     @test Base.samefile(lib, res)
 
+    # test constructor triggered compilation
+    rm(lib)
+    model = BridgeStan.StanModel(stanfile, joinpath(models, "multi", "multi.data.json"))
+    @test isfile(lib)
+
     rm(lib)
     res = BridgeStan.compile_model(stanfile; make_args = ["STAN_THREADS=true"])
     @test Base.samefile(lib, res)
+
 end
 
 

--- a/julia/test/compile_tests.jl
+++ b/julia/test/compile_tests.jl
@@ -12,16 +12,16 @@ models = joinpath(BridgeStan.get_bridgestan_path(), "test_models/")
     rm(lib, force = true)
     res = BridgeStan.compile_model(stanfile; stanc_args = ["--O1"])
     @test Base.samefile(lib, res)
+    rm(lib)
 
     # test constructor triggered compilation
-    rm(lib)
-    model = BridgeStan.StanModel(stanfile, joinpath(models, "multi", "multi.data.json"))
+    model = BridgeStan.StanModel(
+        stanfile,
+        joinpath(models, "multi", "multi.data.json");
+        make_args = ["STAN_THREADS=true"],
+    )
     @test isfile(lib)
-
-    rm(lib)
-    res = BridgeStan.compile_model(stanfile; make_args = ["STAN_THREADS=true"])
-    @test Base.samefile(lib, res)
-
+    @test contains(BridgeStan.model_info(model), "STAN_THREADS=true")
 end
 
 

--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -48,9 +48,10 @@ class StanModel:
 
         :param model_lib: A system path to compiled shared object or a ``.stan``
             file to be compiled.
-        :param data: Either a JSON string literal, a
-            system path to a data file in JSON format ending in ``.json``,
-            or the empty string.
+        :param data: Data for the model. Either a JSON string literal or a
+            system path to a data file in JSON format ending in ``.json``.
+            If the model does not require data, this can be either the
+            empty string or ``None`` (the default).
         :param seed: A pseudo random number generator seed, used for RNG functions
             in the ``transformed data`` block.
         :param stanc_args: A list of arguments to pass to stanc3 if the
@@ -70,6 +71,7 @@ class StanModel:
             **Note:** If this is set for a model, any other models instantiated
             from the *same shared library* will also have the callback set, even
             if they were created *before* this model.
+        :param model_data: Deprecated former name for ``data``.
         :raises FileNotFoundError or PermissionError: If ``model_lib`` is not readable or
             ``data`` is specified and not a path to a readable file.
         :raises RuntimeError: If there is an error instantiating the
@@ -688,8 +690,7 @@ class StanModel:
         """
         Construct a StanModel instance from a ``.stan`` file, compiling if necessary.
 
-        This is equivalent to calling :func:`bridgestan.compile_model`` and then the
-        constructor of this class.
+        DEPRECATED: You should use the constructor on a ``.stan`` file instead.
 
         :param stan_file: A path to a Stan model file.
         :param model_data: A path to data in JSON format.

--- a/python/bridgestan/util.py
+++ b/python/bridgestan/util.py
@@ -1,7 +1,8 @@
 import os
+from typing import Union
 
 
-def validate_readable(f: str) -> None:
+def validate_readable(f: Union[str, os.PathLike]) -> None:
     """
     Raise an error if the specified file is not readable.
 

--- a/python/example.py
+++ b/python/example.py
@@ -10,7 +10,7 @@ bs.set_bridgestan_path("..")
 
 stan = "../test_models/bernoulli/bernoulli.stan"
 data = "../test_models/bernoulli/bernoulli.data.json"
-model = bs.StanModel.from_stan_file(stan, data)
+model = bs.StanModel(stan, data)
 
 print(f"This model's name is {model.name()}.")
 print(f"It has {model.param_num()} parameters.")

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -15,7 +15,11 @@ def test_compile_good():
     assert lib.samefile(res)
     lib.unlink()
 
-    model = bs.StanModel(stanfile, data=STAN_FOLDER / "multi" / "multi.data.json", make_args=["STAN_THREADS=true"])
+    model = bs.StanModel(
+        stanfile,
+        data=STAN_FOLDER / "multi" / "multi.data.json",
+        make_args=["STAN_THREADS=true"],
+    )
     assert lib.exists()
     assert "STAN_THREADS=true" in model.model_info()
 

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -15,12 +15,9 @@ def test_compile_good():
     assert lib.samefile(res)
     lib.unlink()
 
-    model = bs.StanModel(stanfile, data=STAN_FOLDER / "multi" / "multi.data.json")
+    model = bs.StanModel(stanfile, data=STAN_FOLDER / "multi" / "multi.data.json", make_args=["STAN_THREADS=true"])
     assert lib.exists()
-    lib.unlink()
-
-    res = bs.compile_model(stanfile, make_args=["STAN_THREADS=true"])
-    assert lib.samefile(res)
+    assert "STAN_THREADS=true" in model.model_info()
 
 
 def test_compile_bad_ext():

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -14,6 +14,11 @@ def test_compile_good():
     res = bs.compile_model(stanfile, stanc_args=["--O1"])
     assert lib.samefile(res)
     lib.unlink()
+
+    model = bs.StanModel(stanfile, data=STAN_FOLDER / "multi" / "multi.data.json")
+    assert lib.exists()
+    lib.unlink()
+
     res = bs.compile_model(stanfile, make_args=["STAN_THREADS=true"])
     assert lib.samefile(res)
 
@@ -40,4 +45,4 @@ def test_compile_bad_bridgestan():
     with pytest.raises(ValueError, match=r"does not exist"):
         bs.compile.set_bridgestan_path("dummy")
     with pytest.raises(ValueError, match=r"does not contain file 'Makefile'"):
-        bs.compile.set_bridgestan_path(str(STAN_FOLDER))
+        bs.compile.set_bridgestan_path(STAN_FOLDER)

--- a/python/test/test_stanmodel.py
+++ b/python/test/test_stanmodel.py
@@ -12,13 +12,13 @@ def test_constructor():
     # implicit destructor tests in success and fail cases
 
     # test empty data
-    std_so = str(STAN_FOLDER / "stdnormal" / "stdnormal_model.so")
+    std_so = STAN_FOLDER / "stdnormal" / "stdnormal_model.so"
     b1 = bs.StanModel(std_so)
     np.testing.assert_allclose(bool(b1), True)
 
     # test load data
-    bernoulli_so = str(STAN_FOLDER / "bernoulli" / "bernoulli_model.so")
-    bernoulli_data = str(STAN_FOLDER / "bernoulli" / "bernoulli.data.json")
+    bernoulli_so = STAN_FOLDER / "bernoulli" / "bernoulli_model.so"
+    bernoulli_data = STAN_FOLDER / "bernoulli" / "bernoulli.data.json"
     b2 = bs.StanModel(bernoulli_so, bernoulli_data)
     np.testing.assert_allclose(bool(b2), True)
 
@@ -37,11 +37,11 @@ def test_constructor():
         bs.StanModel(bernoulli_so, "nope, not going to find it.json")
 
     # test data load exception
-    throw_data_so = str(STAN_FOLDER / "throw_data" / "throw_data_model.so")
+    throw_data_so = STAN_FOLDER / "throw_data" / "throw_data_model.so"
     with pytest.raises(RuntimeError, match="find this text: datafails"):
         b4 = bs.StanModel(throw_data_so)
 
-    load_sundials = str(STAN_FOLDER / "ode_sundials" / "ode_sundials_model.so")
+    load_sundials = STAN_FOLDER / "ode_sundials" / "ode_sundials_model.so"
     ode_sundials_data = (
         STAN_FOLDER / "ode_sundials" / "ode_sundials.data.json"
     ).read_text()
@@ -49,20 +49,20 @@ def test_constructor():
 
 
 def test_name():
-    std_so = str(STAN_FOLDER / "stdnormal" / "stdnormal_model.so")
+    std_so = STAN_FOLDER / "stdnormal" / "stdnormal_model.so"
     b = bs.StanModel(std_so)
     np.testing.assert_equal("stdnormal_model", b.name())
 
 
 def test_model_info():
-    std_so = str(STAN_FOLDER / "stdnormal" / "stdnormal_model.so")
+    std_so = STAN_FOLDER / "stdnormal" / "stdnormal_model.so"
     b = bs.StanModel(std_so)
     assert "STAN_OPENCL" in b.model_info()
     assert "BridgeStan version: 2." in b.model_info()
 
 
 def test_param_num():
-    full_so = str(STAN_FOLDER / "full" / "full_model.so")
+    full_so = STAN_FOLDER / "full" / "full_model.so"
     b = bs.StanModel(full_so)
     np.testing.assert_equal(1, b.param_num())
     np.testing.assert_equal(1, b.param_num(include_tp=False))
@@ -76,14 +76,14 @@ def test_param_num():
 
 
 def test_param_unc_num():
-    simplex_so = str(STAN_FOLDER / "simplex" / "simplex_model.so")
+    simplex_so = STAN_FOLDER / "simplex" / "simplex_model.so"
     b = bs.StanModel(simplex_so)
     np.testing.assert_equal(5, b.param_num())
     np.testing.assert_equal(4, b.param_unc_num())
 
 
 def test_param_names():
-    matrix_so = str(STAN_FOLDER / "matrix" / "matrix_model.so")
+    matrix_so = STAN_FOLDER / "matrix" / "matrix_model.so"
     b = bs.StanModel(matrix_so)
     np.testing.assert_array_equal(
         ["A.1.1", "A.2.1", "A.3.1", "A.1.2", "A.2.2", "A.3.2"], b.param_names()
@@ -163,13 +163,13 @@ def test_param_names():
 
 
 def test_param_unc_names():
-    matrix_so = str(STAN_FOLDER / "matrix" / "matrix_model.so")
+    matrix_so = STAN_FOLDER / "matrix" / "matrix_model.so"
     b1 = bs.StanModel(matrix_so)
     np.testing.assert_array_equal(
         ["A.1.1", "A.2.1", "A.3.1", "A.1.2", "A.2.2", "A.3.2"], b1.param_unc_names()
     )
 
-    simplex_so = str(STAN_FOLDER / "simplex" / "simplex_model.so")
+    simplex_so = STAN_FOLDER / "simplex" / "simplex_model.so"
     b2 = bs.StanModel(simplex_so)
     np.testing.assert_array_equal(
         ["theta.1", "theta.2", "theta.3", "theta.4"], b2.param_unc_names()
@@ -186,8 +186,8 @@ def cov_constrain(v, D):
 
 
 def test_param_constrain():
-    fr_gaussian_so = str(STAN_FOLDER / "fr_gaussian" / "fr_gaussian_model.so")
-    fr_gaussian_data = str(STAN_FOLDER / "fr_gaussian" / "fr_gaussian.data.json")
+    fr_gaussian_so = STAN_FOLDER / "fr_gaussian" / "fr_gaussian_model.so"
+    fr_gaussian_data = STAN_FOLDER / "fr_gaussian" / "fr_gaussian.data.json"
     bridge = bs.StanModel(fr_gaussian_so, fr_gaussian_data)
 
     D = 4
@@ -211,7 +211,7 @@ def test_param_constrain():
     B = b.reshape(D, D)
     np.testing.assert_allclose(B_expected, B)
 
-    full_so = str(STAN_FOLDER / "full" / "full_model.so")
+    full_so = STAN_FOLDER / "full" / "full_model.so"
     bridge2 = bs.StanModel(full_so)
     rng = bridge2.new_rng(seed=1234)
 
@@ -244,7 +244,7 @@ def test_param_constrain():
         bridge.param_constrain(a, out=scratch_wrong)
 
     # exception handling test in transformed parameters/model (compiled same way)
-    throw_tp_so = str(STAN_FOLDER / "throw_tp" / "throw_tp_model.so")
+    throw_tp_so = STAN_FOLDER / "throw_tp" / "throw_tp_model.so"
     bridge2 = bs.StanModel(throw_tp_so)
 
     y = np.array(np.random.uniform(1))
@@ -252,7 +252,7 @@ def test_param_constrain():
     with pytest.raises(RuntimeError, match="find this text: tpfails"):
         bridge2.param_constrain(y, include_tp=True)
 
-    throw_gq_so = str(STAN_FOLDER / "throw_gq" / "throw_gq_model.so")
+    throw_gq_so = STAN_FOLDER / "throw_gq" / "throw_gq_model.so"
     bridge3 = bs.StanModel(throw_gq_so)
     bridge3.param_constrain(y, include_gq=False)
     with pytest.raises(RuntimeError, match="find this text: gqfails"):
@@ -260,8 +260,8 @@ def test_param_constrain():
 
 
 def test_param_unconstrain():
-    fr_gaussian_so = str(STAN_FOLDER / "fr_gaussian" / "fr_gaussian_model.so")
-    fr_gaussian_data = str(STAN_FOLDER / "fr_gaussian" / "fr_gaussian.data.json")
+    fr_gaussian_so = STAN_FOLDER / "fr_gaussian" / "fr_gaussian_model.so"
+    fr_gaussian_data = STAN_FOLDER / "fr_gaussian" / "fr_gaussian.data.json"
     bridge = bs.StanModel(fr_gaussian_so, fr_gaussian_data)
 
     unc_size = 10
@@ -279,8 +279,8 @@ def test_param_unconstrain():
 
 
 def test_param_unconstrain_json():
-    gaussian_so = str(STAN_FOLDER / "gaussian" / "gaussian_model.so")
-    gaussian_data = str(STAN_FOLDER / "gaussian" / "gaussian.data.json")
+    gaussian_so = STAN_FOLDER / "gaussian" / "gaussian_model.so"
+    gaussian_data = STAN_FOLDER / "gaussian" / "gaussian.data.json"
     bridge = bs.StanModel(gaussian_so, gaussian_data)
 
     # theta = np.array([0.2, 1.9])
@@ -311,8 +311,8 @@ def _bernoulli_jacobian(y, p):
 
 
 def test_log_density():
-    bernoulli_so = str(STAN_FOLDER / "bernoulli" / "bernoulli_model.so")
-    bernoulli_data = str(STAN_FOLDER / "bernoulli" / "bernoulli.data.json")
+    bernoulli_so = STAN_FOLDER / "bernoulli" / "bernoulli_model.so"
+    bernoulli_data = STAN_FOLDER / "bernoulli" / "bernoulli.data.json"
     bridge = bs.StanModel(bernoulli_so, bernoulli_data)
     y = np.asarray([0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
     for _ in range(2):
@@ -327,7 +327,7 @@ def test_log_density():
         lp4 = bridge.log_density(np.array([x_unc]), propto=True, jacobian=False)
         np.testing.assert_allclose(lp4, _bernoulli(y, x))
 
-    throw_lp_so = str(STAN_FOLDER / "throw_lp" / "throw_lp_model.so")
+    throw_lp_so = STAN_FOLDER / "throw_lp" / "throw_lp_model.so"
     bridge2 = bs.StanModel(throw_lp_so)
     y2 = np.array(np.random.uniform(1))
 
@@ -356,7 +356,7 @@ def test_log_density_gradient():
     def _grad_jacobian_true(y_unc):
         return 1
 
-    jacobian_so = str(STAN_FOLDER / "jacobian" / "jacobian_model.so")
+    jacobian_so = STAN_FOLDER / "jacobian" / "jacobian_model.so"
     bridge = bs.StanModel(jacobian_so)
 
     y = np.abs(np.random.normal(1))
@@ -435,7 +435,7 @@ def test_log_density_hessian():
     def _hess_jacobian_true(y_unc):
         return 0
 
-    jacobian_so = str(STAN_FOLDER / "jacobian" / "jacobian_model.so")
+    jacobian_so = STAN_FOLDER / "jacobian" / "jacobian_model.so"
     bridge = bs.StanModel(jacobian_so)
 
     # test value, gradient, hessian, all combos +/- propto, +/- jacobian
@@ -510,8 +510,8 @@ def test_log_density_hessian():
         bridge.log_density_hessian(y_unc, out_grad=scratch_bad)
 
     # test with 5 x 5 Hessian
-    simple_so = str(STAN_FOLDER / "simple" / "simple_model.so")
-    simple_data = str(STAN_FOLDER / "simple" / "simple.data.json")
+    simple_so = STAN_FOLDER / "simple" / "simple_model.so"
+    simple_data = STAN_FOLDER / "simple" / "simple.data.json"
     bridge2 = bs.StanModel(simple_so, simple_data)
 
     D = 5
@@ -522,8 +522,8 @@ def test_log_density_hessian():
 
 
 def test_out_behavior():
-    bernoulli_so = str(STAN_FOLDER / "bernoulli" / "bernoulli_model.so")
-    bernoulli_data = str(STAN_FOLDER / "bernoulli" / "bernoulli.data.json")
+    bernoulli_so = STAN_FOLDER / "bernoulli" / "bernoulli_model.so"
+    bernoulli_data = STAN_FOLDER / "bernoulli" / "bernoulli.data.json"
     smb = bs.StanModel(bernoulli_so, bernoulli_data)
 
     grads = []
@@ -558,8 +558,8 @@ def test_bernoulli():
     def _bernoulli(y, p):
         return np.sum(y * np.log(p) + (1 - y) * np.log(1 - p))
 
-    bernoulli_so = str(STAN_FOLDER / "bernoulli" / "bernoulli_model.so")
-    bernoulli_data = str(STAN_FOLDER / "bernoulli" / "bernoulli.data.json")
+    bernoulli_so = STAN_FOLDER / "bernoulli" / "bernoulli_model.so"
+    bernoulli_data = STAN_FOLDER / "bernoulli" / "bernoulli.data.json"
     smb = bs.StanModel(bernoulli_so, bernoulli_data)
     np.testing.assert_string_equal(smb.name(), "bernoulli_model")
     np.testing.assert_allclose(smb.param_unc_num(), 1)
@@ -583,8 +583,8 @@ def test_multi():
     def _grad_multi(x):
         return -x
 
-    multi_so = str(STAN_FOLDER / "multi" / "multi_model.so")
-    multi_data = str(STAN_FOLDER / "multi" / "multi.data.json")
+    multi_so = STAN_FOLDER / "multi" / "multi_model.so"
+    multi_data = STAN_FOLDER / "multi" / "multi.data.json"
 
     smm = bs.StanModel(multi_so, multi_data)
     x = np.random.normal(size=smm.param_unc_num())
@@ -594,8 +594,8 @@ def test_multi():
 
 
 def test_gaussian():
-    lib = str(STAN_FOLDER / "gaussian" / "gaussian_model.so")
-    data = str(STAN_FOLDER / "gaussian" / "gaussian.data.json")
+    lib = STAN_FOLDER / "gaussian" / "gaussian_model.so"
+    data = STAN_FOLDER / "gaussian" / "gaussian.data.json"
 
     model = bs.StanModel(lib, data)
 
@@ -614,8 +614,8 @@ def test_gaussian():
 
 
 def test_fr_gaussian():
-    lib = str(STAN_FOLDER / "fr_gaussian" / "fr_gaussian_model.so")
-    data = str(STAN_FOLDER / "fr_gaussian" / "fr_gaussian.data.json")
+    lib = STAN_FOLDER / "fr_gaussian" / "fr_gaussian_model.so"
+    data = STAN_FOLDER / "fr_gaussian" / "fr_gaussian.data.json"
     model = bs.StanModel(lib, data)
 
     size = 16
@@ -655,7 +655,7 @@ def test_stdout_capture():
     theta = 0.1
 
     m = bs.StanModel(
-        str(STAN_FOLDER / "print" / "print_model.so"), capture_stan_prints=False
+        STAN_FOLDER / "print" / "print_model.so", capture_stan_prints=False
     )
 
     with contextlib.redirect_stdout(io.StringIO()) as f:
@@ -666,7 +666,7 @@ def test_stdout_capture():
     assert captured.splitlines()[0] == "Hello from Python!"
     assert "Stan" not in captured
 
-    m2 = bs.StanModel(str(STAN_FOLDER / "print" / "print_model.so"))
+    m2 = bs.StanModel(STAN_FOLDER / "print" / "print_model.so")
 
     with contextlib.redirect_stdout(io.StringIO()) as f:
         print("Hello from Python!")
@@ -708,13 +708,13 @@ def test_stdout_capture():
 
 def test_reload_warning():
     lib = STAN_FOLDER / "fr_gaussian" / "fr_gaussian_model.so"
-    data = str(STAN_FOLDER / "fr_gaussian" / "fr_gaussian.data.json")
-    model = bs.StanModel(str(lib), data)
+    data = STAN_FOLDER / "fr_gaussian" / "fr_gaussian.data.json"
+    model = bs.StanModel(lib, data)
 
     relative_lib = lib.relative_to(STAN_FOLDER.parent)
     assert not relative_lib.is_absolute()
     with pytest.warns(UserWarning, match="may not update the library"):
-        model2 = bs.StanModel(str(relative_lib), data)
+        model2 = bs.StanModel(relative_lib, data)
 
 
 @pytest.fixture(scope="module")
@@ -726,7 +726,7 @@ def recompile_simple():
     lib.unlink(missing_ok=True)
     res = bs.compile_model(stanfile, make_args=["BRIDGESTAN_AD_HESSIAN=true"])
 
-    yield str(res)
+    yield res
 
     lib.unlink(missing_ok=True)
     bs.compile_model(stanfile, make_args=["STAN_THREADS=true"])
@@ -734,7 +734,7 @@ def recompile_simple():
 
 @pytest.mark.ad_hessian
 def test_hessian_autodiff(recompile_simple):
-    simple_data = str(STAN_FOLDER / "simple" / "simple.data.json")
+    simple_data = STAN_FOLDER / "simple" / "simple.data.json"
     model = bs.StanModel(recompile_simple, simple_data)
     assert "BRIDGESTAN_AD_HESSIAN=true" in model.model_info()
     D = 5
@@ -746,7 +746,7 @@ def test_hessian_autodiff(recompile_simple):
 
 @pytest.mark.ad_hessian
 def test_hvp_autodiff(recompile_simple):
-    simple_data = str(STAN_FOLDER / "simple" / "simple.data.json")
+    simple_data = STAN_FOLDER / "simple" / "simple.data.json"
     model = bs.StanModel(recompile_simple, simple_data)
     assert "BRIDGESTAN_AD_HESSIAN=true" in model.model_info()
     D = 5


### PR DESCRIPTION
Closes #187.

Changes:
- Python: `StanModel.from_stan_file` is deprecated. The logic is subsumed in the constructor, which will trigger compilation if the file provided ends in `.stan`
- Python: The `model_data` argument is renamed to `data`. The previous argument still works but issues a warning.
- Python: All functions which accepted strings for file paths now also accept the [`os.PathLike`](https://docs.python.org/3/library/os.html#os.PathLike) interface
- Julia: The `StanModel(;stan_file,...)` overload is deprecated. This logic is now subsumed in the constructor, which will trigger compilation if the file provided ends in `.stan`