### PR TITLE
Misc. cleanups

### DIFF
--- a/R/R/compile.R
+++ b/R/R/compile.R
@@ -43,7 +43,7 @@ get_bridgestan_path <- function() {
         tryCatch({
             verify_bridgestan_path(path)
         }, error = function(e) {
-            print(paste0("Bridgestan not found at location specified by $BRIDGESTAN ",
+            print(paste0("BridgeStan not found at location specified by $BRIDGESTAN ",
                 "environment variable, downloading version ", packageVersion("bridgestan"),
                 " to ", path))
             get_bridgestan_src()

--- a/R/R/download.R
+++ b/R/R/download.R
@@ -10,7 +10,7 @@ get_bridgestan_src <- function() {
 
     dir.create(HOME_BRIDGESTAN, showWarnings = FALSE, recursive = TRUE)
     temp <- tempfile()
-    err_text <- paste("Failed to download Bridgestan", current_version, "from github.com.")
+    err_text <- paste("Failed to download BridgeStan", current_version, "from github.com.")
     for (i in 1:RETRIES) {
         tryCatch({
             download.file(url, destfile = temp, mode = "wb", quiet = TRUE, method = "auto")

--- a/python/bridgestan/compile.py
+++ b/python/bridgestan/compile.py
@@ -46,7 +46,7 @@ def set_bridgestan_path(path: Union[str, os.PathLike]) -> None:
     os.environ["BRIDGESTAN"] = path
 
 
-def get_bridgestan_path():
+def get_bridgestan_path() -> str:
     """
     Get the path to BridgeStan.
 
@@ -66,14 +66,14 @@ def get_bridgestan_path():
             verify_bridgestan_path(path)
         except ValueError:
             print(
-                "Bridgestan not found at location specified by $BRIDGESTAN "
+                "BridgeStan not found at location specified by $BRIDGESTAN "
                 f"environment variable, downloading version {__version__} to {path}"
             )
             get_bridgestan_src()
             num_files = len(list(HOME_BRIDGESTAN.iterdir()))
             if num_files >= 5:
                 warnings.warn(
-                    f"Found {num_files} different versions of Bridgestan in {HOME_BRIDGESTAN}. "
+                    f"Found {num_files} different versions of BridgeStan in {HOME_BRIDGESTAN}. "
                     "Consider deleting old versions to save space."
                 )
             print("Done!")
@@ -81,7 +81,7 @@ def get_bridgestan_path():
     return path
 
 
-def generate_so_name(model: Path):
+def generate_so_name(model: Path) -> Path:
     name = model.stem
     return model.with_stem(f"{name}_model").with_suffix(".so")
 
@@ -138,7 +138,7 @@ def compile_model(
     return output
 
 
-def windows_dll_path_setup():
+def windows_dll_path_setup() -> None:
     """Add tbb.dll to %PATH% on Windows."""
     global WINDOWS_PATH_SET
     if IS_WINDOWS and not WINDOWS_PATH_SET:
@@ -180,7 +180,6 @@ def windows_dll_path_setup():
                 os.path.dirname(out.stdout.decode().splitlines()[0])
             )
             os.add_dll_directory(mingw_dir)
-            WINDOWS_PATH_SET &= True
         except:
             # no default location
             warnings.warn(

--- a/python/bridgestan/download.py
+++ b/python/bridgestan/download.py
@@ -12,7 +12,7 @@ CURRENT_BRIDGESTAN = HOME_BRIDGESTAN / f"bridgestan-{__version__}"
 RETRIES = 5
 
 
-def get_bridgestan_src():
+def get_bridgestan_src() -> None:
     """
     Download and unzip the BridgeStan source distribution for this version
 
@@ -24,7 +24,7 @@ def get_bridgestan_src():
     )
     HOME_BRIDGESTAN.mkdir(exist_ok=True)
 
-    err_text = f"Failed to download Bridgestan {__version__} from github.com."
+    err_text = f"Failed to download BridgeStan {__version__} from github.com."
     for i in range(1, 1 + RETRIES):
         try:
             file_tmp, _ = urllib.request.urlretrieve(url, filename=None)


### PR DESCRIPTION
While looking into #190, I found a few small improvements:

- Using `ctypes.byref` is cheaper than actually constructing a `ctypes.pointer` 
- Some missing return type annotations
- A few places where we said 'Bridgestan' instead of 'BridgeStan'