### PR TITLE
Add implementation details docs page, note on propto=True for log_density

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -15,4 +15,4 @@ going on "behind the scenes".
     internals/development
     internals/testing
     internals/documentation
-
+    internals/details

--- a/docs/internals/details.rst
+++ b/docs/internals/details.rst
@@ -4,31 +4,41 @@ Implementation Details
 
 .. _log_density_propto:
 
-``log_density`` with ``propto=true``
-------------------------------------
+Speed of the ``propto`` argument
+--------------------------------
 
 The log density function provided by a Stan model has
-the ability to be calculated up to an additive constant.
+the ability drop additive constants from the calculation.
 This is indicated by the ``propto`` ("``prop``\ortional  ``to``")
 argument to function.
-Usually, this is done for efficiency reasons, as the constant
-terms may require computation that is not necessary for calculating
-gradients or most sampling algorithms.
+
+If you are using an application such as an MCMC algorithm which requires
+gradients and only needs the log density up to a proportion, setting
+``propto=True`` will be at least as fast as setting ``propto=False``
+and is generally recommended (and the default value).
 
 However, in the case of the ``log_density`` function (which does not calculate
-derivatives), this argument may make the calculation **slower**. This is because
-the implementation of this argument relies on the presence of autodiff types
-(``var``\s, in the terminology of Stan's math library) to determine what is or
-is not constant with respect to the parameters. If not for this (and indeed, if
-the argument is set to ``false``), the calculation of the log density is able to be
-computed using only primitive types (``double``\s).
+derivatives), this argument has the potential to *slow down* computation, and we
+recommend setting it to ``False`` or timing it for your model of interest before
+proceeding. Note that the default value of ``propto`` is ``True`` for consistency
+with the versions of the function that do calculate gradients, so extra care is needed.
+
+Why is ``log_density`` different?
+_________________________________
+
+The implementation of the ``propto`` argument relies on the presence
+of autodiff types (``var``\s, in the terminology of Stan's math library)
+to determine what is or is not constant with respect to the parameters.
+When the argument is ``False``, the calculation of the log density is able to be
+computed using only variables of type ``double``.
 
 The consequence of this is that, if the ``propto`` argument is set to ``true``,
 the ``log_density`` function will at a minimum need to perform more allocations
 than if it were set to ``false``. There may be an even higher cost, due to functions
 such as |reduce_sum|_ or Stan's ODE integraters changing their behavior when applied
 to autodiff types and performing additional work which is thrown away when gradients
-are not needed.
+are not needed. These additional computations can quickly overwhelm any speed up
+received by dropping additive constants in practice.
 
 
 .. |reduce_sum| replace:: ``reduce_sum``

--- a/docs/internals/details.rst
+++ b/docs/internals/details.rst
@@ -1,0 +1,36 @@
+Implementation Details
+======================
+
+
+.. _log_density_propto:
+
+``log_density`` with ``propto=true``
+------------------------------------
+
+The log density function provided by a Stan model has
+the ability to be calculated up to an additive constant.
+This is indicated by the ``propto`` ("``prop``\ortional  ``to``")
+argument to function.
+Usually, this is done for efficiency reasons, as the constant
+terms may require computation that is not necessary for calculating
+gradients or most sampling algorithms.
+
+However, in the case of the ``log_density`` function (which does not calculate
+derivatives), this argument may make the calculation **slower**. This is because
+the implementation of this argument relies on the presence of autodiff types
+(``var``\s, in the terminology of Stan's math library) to determine what is or
+is not constant with respect to the parameters. If not for this (and indeed, if
+the argument is set to ``false``), the calculation of the log density is able to be
+computed using only primitive types (``double``\s).
+
+The consequence of this is that, if the ``propto`` argument is set to ``true``,
+the ``log_density`` function will at a minimum need to perform more allocations
+than if it were set to ``false``. There may be an even higher cost, due to functions
+such as |reduce_sum|_ or Stan's ODE integraters changing their behavior when applied
+to autodiff types and performing additional work which is thrown away when gradients
+are not needed.
+
+
+.. |reduce_sum| replace:: ``reduce_sum``
+.. _reduce_sum: https://mc-stan.org/docs/stan-users-guide/reduce-sum.html
+

--- a/docs/internals/details.rst
+++ b/docs/internals/details.rst
@@ -1,5 +1,5 @@
-Implementation Details
-======================
+Stan Implementation Details
+===========================
 
 
 .. _log_density_propto:
@@ -8,7 +8,7 @@ Speed of the ``propto`` argument
 --------------------------------
 
 The log density function provided by a Stan model has
-the ability drop additive constants from the calculation.
+the ability to drop additive constants from the calculation.
 This is indicated by the ``propto`` ("``prop``\ortional  ``to``")
 argument to function.
 


### PR DESCRIPTION
This is a bit of a weird thing I've been thinking about recently that it is good to alert users for. It's related to #165 and #180.

Basically `propto=True` requires we pass `vars` to Stan. Before #165, we were even calling `grad`, wasting a lot of computation. Since #165, we no longer call grad, but it still may lead to more work than you'd expect, since the Stan math library assumes (justifiably) that if you're calling a function with `var`s you will want gradients, and so it can do some pre-computation for you. Because we never call/use `grad()` in `log_density`, this is wasted effort.

The big offenders are the higher order functions like `reduce_sum`, which basically calculate their entire gradients in the "forward pass".

I wrote up a docs page on implementation details and added a section about this. I'm not sure if it should be linked other places or not.