### PR TITLE
Python: allow ctypes pointers for in/out parameters

### DIFF
--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -16,11 +16,15 @@ from .util import validate_readable
 
 def array_ptr(*args, **kwargs):
     """
-    A version of np.ctypeslib.ndpointer
-    which allows raw ctypes pointers
+    Return a new class which can be used in a ctypes signature
+    to accept either a numpy array or a compatible
+    ``ctypes.POINTER`` instance.
+
+    All arguments are forwarded to :func:`np.ctypeslib.ndpointer`.
     """
     np_type = ndpointer(*args, **kwargs)
-    ctypes_type = ctypes.POINTER(ctypes.c_double)
+    base = np.ctypeslib.as_ctypes_type(np_type._dtype_)
+    ctypes_type = ctypes.POINTER(base)
 
     def from_param(cls, obj):
         if isinstance(obj, (ctypes_type, ctypes.Array)):

--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -1,6 +1,6 @@
 import ctypes
 import warnings
-from os import PathLike, fspath, write
+from os import PathLike, fspath
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 

--- a/python/test/test_stanmodel.py
+++ b/python/test/test_stanmodel.py
@@ -1,3 +1,4 @@
+import ctypes
 from pathlib import Path
 
 import numpy as np
@@ -274,7 +275,7 @@ def test_param_unconstrain():
     c2 = bridge.param_unconstrain(b, out=scratch)
     np.testing.assert_allclose(a, c2)
     scratch_wrong = np.zeros(16)
-    with pytest.raises(ValueError):
+    with pytest.raises(ctypes.ArgumentError):
         bridge.param_unconstrain(b, out=scratch_wrong)
 
 
@@ -294,7 +295,7 @@ def test_param_unconstrain_json():
     np.testing.assert_allclose(theta_unc, theta_unc_j_test2)
 
     scratch_bad = np.zeros(10)
-    with pytest.raises(ValueError):
+    with pytest.raises(ctypes.ArgumentError):
         bridge.param_unconstrain_json(theta_json, out=scratch_bad)
 
 
@@ -400,7 +401,7 @@ def test_log_density_gradient():
     np.testing.assert_allclose(_grad_logp(y_unc) + _grad_jacobian_true(y_unc), grad[0])
     #
     scratch_bad = np.zeros(bridge.param_unc_num() + 10)
-    with pytest.raises(ValueError):
+    with pytest.raises(ctypes.ArgumentError):
         bridge.log_density_gradient(y_unc, out=scratch_bad)
 
 
@@ -506,7 +507,7 @@ def test_log_density_hessian():
     np.testing.assert_allclose(_grad_logp(y_unc) + _grad_jacobian_true(y_unc), grad[0])
     #
     scratch_bad = np.zeros(bridge.param_unc_num() + 10)
-    with pytest.raises(ValueError):
+    with pytest.raises(ctypes.ArgumentError):
         bridge.log_density_hessian(y_unc, out_grad=scratch_bad)
 
     # test with 5 x 5 Hessian


### PR DESCRIPTION
Closes #190

This makes the minimal changes required to accept `ctypes.POINTER(ctypes.c_double)` types alongside numpy arrays for parameter arrays and out parameters