### PR TITLE
Revert "Bump r-lib/actions from 2.6.5 to 2.7.2"

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -51,10 +51,10 @@ jobs:
 
 
       - name: Install R
-        uses: r-lib/actions/setup-r@v2.7.2
+        uses: r-lib/actions/setup-r@v2.6.5
 
       - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2.7.2
+        uses: r-lib/actions/setup-r-dependencies@v2.6.5
         with:
           packages: |
             any::roxygen2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -193,10 +193,10 @@ jobs:
           submodules: recursive
 
       - name: Install R
-        uses: r-lib/actions/setup-r@v2.7.2
+        uses: r-lib/actions/setup-r@v2.6.5
 
       - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2.7.2
+        uses: r-lib/actions/setup-r-dependencies@v2.6.5
         with:
           packages: |
             any::R6


### PR DESCRIPTION
Reverts roualdes/bridgestan#208

It seems this may have broken the Windows tests for R. I'm still investigating.