### PR TITLE
Fix Windows R tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -233,10 +233,16 @@ jobs:
         run: |
           cd R/tests/testthat
           gcc -fpic -shared -o test_collisions.dll test_collisions.c
+          if (!$LASTEXITCODE.Equals(0)) {exit $LASTEXITCODE}
+          ls
           cd ../..
+          ls
           Rscript -e 'devtools::test(reporter = c(\"summary\", \"fail\"))'
+          if (!$LASTEXITCODE.Equals(0)) {exit $LASTEXITCODE}
           Rscript -e 'install.packages(getwd(), repos=NULL, type=\"source\")'
+          if (!$LASTEXITCODE.Equals(0)) {exit $LASTEXITCODE}
           Rscript example.R
+          if (!$LASTEXITCODE.Equals(0)) {exit $LASTEXITCODE}
         env:
           BRIDGESTAN: ${{ github.workspace }}
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -234,12 +234,10 @@ jobs:
           cd R/tests/testthat
           gcc -fpic -shared -o test_collisions.dll test_collisions.c
           if (!$LASTEXITCODE.Equals(0)) {exit $LASTEXITCODE}
-          ls
           cd ../..
-          ls
-          Rscript -e 'devtools::test(reporter = c(\"summary\", \"fail\"))'
+          Rscript -e 'devtools::test(reporter = c("summary", "fail"))'
           if (!$LASTEXITCODE.Equals(0)) {exit $LASTEXITCODE}
-          Rscript -e 'install.packages(getwd(), repos=NULL, type=\"source\")'
+          Rscript -e 'install.packages(getwd(), repos=NULL, type="source")'
           if (!$LASTEXITCODE.Equals(0)) {exit $LASTEXITCODE}
           Rscript example.R
           if (!$LASTEXITCODE.Equals(0)) {exit $LASTEXITCODE}


### PR DESCRIPTION
The Windows runners [recently updated to PowerShell 7.4](https://github.com/actions/runner-images/issues/9115), which [changed some string quoting behavior](https://stackoverflow.com/a/63627261).

This broke the tests, but because R doesn't really signal its errors in a way Windows likes and https://github.com/actions/runner-images/issues/6668, they stayed green. This fixes them and makes it so we should notice if it happens again.