### PR TITLE
improve panic error message on the Rust example

### DIFF
--- a/rust/examples/example.rs
+++ b/rust/examples/example.rs
@@ -23,13 +23,10 @@ fn main() {
     let model = match Model::new(&lib, Some(data), seed) {
         Ok(model) => model,
         Err(BridgeStanError::ConstructFailed(msg)) => {
-            panic!(
-                "Model initialization failed. Error message from Stan was {}",
-                msg
-            )
+            panic!("Model initialization failed. Error message from Stan was {msg}")
         }
-        _ => {
-            panic!("Unexpected error")
+        Err(e) => {
+            panic!("Unexpected error:\n{e}")
         }
     };
 


### PR DESCRIPTION
a simple improvement suggestion: a better error message on the Rust example.

e.g.: in case of forgetting to compile the model with `STAN_THREADS=true`.