### PR TITLE
Move Julia TBB detection to instantiation time

### DIFF
--- a/R/R/bridgestan.R
+++ b/R/R/bridgestan.R
@@ -21,7 +21,7 @@ StanModel <- R6::R6Class("StanModel",
       }
 
       if (.Platform$OS.type == "windows"){
-        windows_path_setup()
+        windows_dll_path_setup()
         lib_old <- lib
         lib <- paste0(tools::file_path_sans_ext(lib), ".dll")
         file.copy(from=lib_old, to=lib)

--- a/R/R/compile.R
+++ b/R/R/compile.R
@@ -113,12 +113,12 @@ windows_dll_path_setup <- function() {
     if (.Platform$OS.type == "windows" && !WINDOWS_PATH_SET) {
 
         if (tbb_found()) {
-            WINDOWS_PATH_SET <<- TRUE
+            assign("WINDOWS_PATH_SET", TRUE, envir = .GlobalEnv)
         } else {
             tbb_path <- file.path(get_bridgestan_path(), "stan", "lib", "stan_math",
                 "lib", "tbb")
             Sys.setenv(PATH = paste(tbb_path, Sys.getenv("PATH"), sep = ";"))
-            WINDOWS_PATH_SET <<- tbb_found()
+            assign("WINDOWS_PATH_SET", tbb_found(), envir = .GlobalEnv)
         }
     }
 }

--- a/R/R/compile.R
+++ b/R/R/compile.R
@@ -102,13 +102,23 @@ compile_model <- function(stan_file, stanc_args = NULL, make_args = NULL) {
     return(output)
 }
 
-windows_path_setup <- function() {
-    if (.Platform$OS.type == "windows") {
-        suppressWarnings(out <- system2("where.exe", "tbb.dll", stdout = NULL, stderr = NULL))
-        if (out != 0) {
+tbb_found <- function() {
+    suppressWarnings(out <- system2("where.exe", "tbb.dll", stdout = NULL, stderr = NULL))
+    return(out == 0)
+}
+
+WINDOWS_PATH_SET <- FALSE
+
+windows_dll_path_setup <- function() {
+    if (.Platform$OS.type == "windows" && !WINDOWS_PATH_SET) {
+
+        if (tbb_found()) {
+            WINDOWS_PATH_SET <<- TRUE
+        } else {
             tbb_path <- file.path(get_bridgestan_path(), "stan", "lib", "stan_math",
                 "lib", "tbb")
             Sys.setenv(PATH = paste(tbb_path, Sys.getenv("PATH"), sep = ";"))
+            WINDOWS_PATH_SET <<- tbb_found()
         }
     }
 }

--- a/julia/src/BridgeStan.jl
+++ b/julia/src/BridgeStan.jl
@@ -53,20 +53,4 @@ function StanModel(;
     StanModel(stan_file, data, seed; stanc_args, make_args)
 end
 
-
-function __init__()
-    # On Windows, we may need to add TBB to %PATH%
-    if Sys.iswindows()
-        try
-            run(pipeline(`where.exe tbb.dll`, stdout = devnull, stderr = devnull))
-        catch
-            # add TBB to %PATH%
-            ENV["PATH"] =
-                joinpath(get_bridgestan_path(), "stan", "lib", "stan_math", "lib", "tbb") *
-                ";" *
-                ENV["PATH"]
-        end
-    end
-end
-
 end

--- a/julia/src/compile.jl
+++ b/julia/src/compile.jl
@@ -90,3 +90,29 @@ function compile_model(
     end
     return output_file
 end
+
+WINDOWS_PATH_SET = Ref{Bool}(false)
+
+function tbb_found()
+    try
+        run(pipeline(`where.exe tbb.dll`, stdout = devnull, stderr = devnull))
+    catch
+        return false
+    end
+    return true
+end
+
+function windows_dll_path_setup()
+    if Sys.iswindows() && !(WINDOWS_PATH_SET[])
+        if tbb_found()
+            WINDOWS_PATH_SET[] = true
+        else
+            # add TBB to %PATH%
+            ENV["PATH"] =
+                joinpath(get_bridgestan_path(), "stan", "lib", "stan_math", "lib", "tbb") *
+                ";" *
+                ENV["PATH"]
+            WINDOWS_PATH_SET[] = tbb_found()
+        end
+    end
+end

--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -68,6 +68,8 @@ mutable struct StanModel
             end
         end
 
+        windows_dll_path_setup()
+
         lib = Libc.Libdl.dlopen(lib)
 
         err = Ref{Cstring}()


### PR DESCRIPTION
Unlike Python or R, Julia was setting up the Windows PATH at startup rather than at runtime. Among other things, this meant that calls to `set_bridgestan_path` couldn't influence this, since by the time that function was available, it was already too late.

This is in part thanks to a forum report: https://discourse.mc-stan.org/t/various-compilation-problems-with-various-interfaces/34155/5