### PR TITLE
Update install doc after R build features

### DIFF
--- a/R/README.md
+++ b/R/README.md
@@ -6,7 +6,7 @@
 
 **From Github**:
 ```R
-devtools::install_github("https://github.com/roualdes/bridgestan", subdir="R")
+remotes::install_github("https://github.com/roualdes/bridgestan", subdir="R")
 ```
 
 **From the downloaded repository**:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ compiler combinations.
 ## Installing BridgeStan
 
 Installing the core of BridgeStan is as simple as
-[installing a C++ toolchain](https://mc-stan.org/docs/cmdstan-guide/cmdstan-installation.html#cpp-toolchain)
+[installing a C++ toolchain](https://mc-stan.org/docs/cmdstan-guide/installation.html#cpp-toolchain)
 (libraries, compiler, and the `make` command), and downloading this
 repository. To download the latest development version, you can run
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,10 @@ extensions = [
     "myst_parser",
 ]
 
+myst_enable_extensions = [
+    "substitution"
+]
+
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md"]
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -12,7 +12,7 @@ Stan requires a C++ tool chain consisting of
 
 Here are complete instructions by platform for installing both, from the CmdStan installation instructions.
 
-* `C++ tool chain installation - CmdStan User's Guide <https://mc-stan.org/docs/cmdstan-guide/cmdstan-installation.html#cpp-toolchain>`__
+* `C++ tool chain installation - CmdStan User's Guide <https://mc-stan.org/docs/cmdstan-guide/installation.html#cpp-toolchain>`__
 
 Downloading BridgeStan
 ----------------------

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -17,15 +17,17 @@ Here are complete instructions by platform for installing both, from the CmdStan
 Downloading BridgeStan
 ----------------------
 
+.. note::
+    The :doc:`Julia <languages/julia>`, :doc:`Python <languages/python>`, and :doc:`R <languages/r>`
+    interfaces will download the source for you the first time you compile a model.
+    This section is optional for users primarily interested in those interfaces.
+
+
 Installing BridgeStan is as simple as ensuring that the above requirements are installed and then downloading
 the source repository. All of the following ways of downloading BridgeStan will additionally download the
 `Stan <https://github.com/stan-dev/stan>`__ and `Stan Math <https://github.com/stan-dev/math>`__ libraries for you,
 and no additional dependencies are required to be installed separately for the C++ source code.
 
-As of version 1.0.2, the :doc:`Julia <languages/julia>` and
-:doc:`Python <languages/python>` interfaces will download
-the source for you the first time you compile a model, so
-this section is optional.
 
 Downloading a released archive
 ______________________________

--- a/docs/internals/development.rst
+++ b/docs/internals/development.rst
@@ -31,6 +31,7 @@ Python
 ------
 
 * Python dependencies:
+
   * `NumPy <https://numpy.org/>`_
 
 * We autoformat code with `black <https://black.readthedocs.io/en/stable/>`_.
@@ -39,6 +40,7 @@ Julia
 -----
 
 * Julia dependencies:
+
   * `LazyArtifacts <https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/>`_
 
 * Julia code is formatted using `JuliaFormatter <https://github.com/domluna/JuliaFormatter.jl>`_.
@@ -47,6 +49,7 @@ R
 -
 
 * R dependencies:
+
   * `R6 <https://cran.r-project.org/web/packages/R6/index.html>`_
 
 Rust

--- a/docs/internals/testing.rst
+++ b/docs/internals/testing.rst
@@ -16,6 +16,11 @@ Note: The additional functionality provided by
 but in order to facilitate the same built models being used in
 all tests we use it regardless of interface.
 
+Tests for the compilation utilities in the various interfaces also rely on being
+able to find the BridgeStan source. This is best done with the environment variable
+``BRIDGESTAN``. On Linux and macOS, this can be set with ``export BRIDGESTAN=\`pwd\```.
+On Windows, use ``$env:BRIDGESTAN=$pwd``.
+
 Python
 ______
 

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -37,7 +37,7 @@ BridgeStan is registered on JuliaRegistries each release.
 ```
 
 
-The first time you compile a model, the BridgeStan source code will be downloaded as an [Artifact](https://pkgdocs.julialang.org/v1/artifacts/). If you prefer to use a source distribution of BridgeStan, consult the following section.
+The first time you compile a model, the BridgeStan source code for your current version will be downloaded as an [Artifact](https://pkgdocs.julialang.org/v1/artifacts/). If you prefer to use a source distribution of BridgeStan, consult the following section.
 
 
 Note that the system pre-requisites from the [Getting Started Guide](../getting-started.rst) are still required and will not be automatically installed by this method.

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -40,7 +40,7 @@ BridgeStan is registered on JuliaRegistries each release.
 The first time you compile a model, the BridgeStan source code for your current version will be downloaded as an [Artifact](https://pkgdocs.julialang.org/v1/artifacts/). If you prefer to use a source distribution of BridgeStan, consult the following section.
 
 
-Note that the system pre-requisites from the [Getting Started Guide](../getting-started.rst) are still required and will not be automatically installed by this method.
+Note that the system pre-requisites from the [Getting Started guide](../getting-started.rst) are still required and will not be automatically installed by this method.
 
 
 <a id='From-Source'></a>
@@ -70,6 +70,9 @@ Or, since you have already downloaded the repository, you can run
 
 
 from the BridgeStan folder.
+
+
+To use the BridgeStan source you've manually downloaded instead of one the package will download for you, you must use [`set_bridgestan_path()`](BridgeStan.set_bridgestan_path!) or the `$BRIDGESTAN` environment variable.
 
 
 Note that the Julia package depends on Julia 1.8+.

--- a/docs/languages/python.rst
+++ b/docs/languages/python.rst
@@ -22,6 +22,8 @@ The first time you compile a model, the BridgeStan source code for your current 
 will be downloaded and placed in :file:`~/.bridgestan/`.
 If you prefer to use a source distribution of BridgeStan, consult the following section.
 
+Note that the system pre-requisites from the :doc:`Getting Started guide <../getting-started>` 
+are still required and will not be automatically installed by this method.
 
 From Source
 ___________

--- a/docs/languages/python.rst
+++ b/docs/languages/python.rst
@@ -18,9 +18,9 @@ For convenience, BridgeStan is uploaded to the Python Package Index each release
     pip install bridgestan
 
 
-The first time you compile a model, the BridgeStan source code will be downloaded
-and placed in :file:`~/.bridgestan/`. If you prefer to use a source distribution of BridgeStan,
-consult the following section.
+The first time you compile a model, the BridgeStan source code for your current version
+will be downloaded and placed in :file:`~/.bridgestan/`.
+If you prefer to use a source distribution of BridgeStan, consult the following section.
 
 
 From Source

--- a/docs/languages/r.md
+++ b/docs/languages/r.md
@@ -24,6 +24,9 @@ The first time you compile a model, the BridgeStan source code for your current 
 will be downloaded and placed in :file:`~/.bridgestan/`.
 If you prefer to use a source distribution of BridgeStan, consult the following section.
 
+Note that the system pre-requisites from the [Getting Started guide](../getting-started.rst)
+are still required and will not be automatically installed by this method.
+
 ### From Source
 
 This assumes you have followed the [Getting Started guide](../getting-started.rst)

--- a/docs/languages/r.md
+++ b/docs/languages/r.md
@@ -4,27 +4,44 @@
 
 ## Installation
 
-This assumes you have followed the [Getting Started guide](../getting-started.rst)
-to install BridgeStan's pre-requisites and downloaded a copy of the BridgeStan source code.
+```{note}
+Mac users have reported issues when using a copy of R installed from [conda-forge](https://conda-forge.org/). If you encounter an issue, you may need to use R from the official [R project website](https://www.r-project.org/) or a system package manager like `brew`.
+```
 
+### From inside R
+
+While BridgeStan is not available on CRAN, you can install the R package from the source code
+using the `devtools` package:
 
 ```R
 devtools::install_github("https://github.com/roualdes/bridgestan", subdir="R")
 ```
 
-Or, since you have already downloaded the repository, you can run
+To install a specific version of BridgeStan you can use the argument `ref`,
+for example, {{ "`ref=\"vVERSION\"`".replace("VERSION", env.config.version) }}.
 
+The first time you compile a model, the BridgeStan source code for your current version
+will be downloaded and placed in :file:`~/.bridgestan/`.
+If you prefer to use a source distribution of BridgeStan, consult the following section.
+
+### From Source
+
+This assumes you have followed the [Getting Started guide](../getting-started.rst)
+to install BridgeStan's pre-requisites and downloaded a copy of the BridgeStan source code.
+
+To install the R package from the source code, run:
 ```R
 install.packages(file.path(getwd(),"R"), repos=NULL, type="source")
 ```
 from the BridgeStan folder.
 
+To use the BridgeStan source you've manually downloaded instead of
+one the package will download for you, you must use
+[`set_bridgestan_path()`](#function-set-bridgestan-path) or the `$BRIDGESTAN`
+environment variable.
+
 Note that the R package depends on R 3+ and R6, and will install R6 if it is not
 already installed.
-
-```{note}
-Mac users have reported issues when using a copy of R installed from [conda-forge](https://conda-forge.org/). If you encounter an issue, you may need to use R from the official [R project website](https://www.r-project.org/) or a system package manager like `brew`.
-```
 
 ## Example Program
 

--- a/docs/languages/r.md
+++ b/docs/languages/r.md
@@ -11,10 +11,10 @@ Mac users have reported issues when using a copy of R installed from [conda-forg
 ### From inside R
 
 While BridgeStan is not available on CRAN, you can install the R package from the source code
-using the `devtools` package:
+using the `remotes` package:
 
 ```R
-devtools::install_github("https://github.com/roualdes/bridgestan", subdir="R")
+remotes::install_github("https://github.com/roualdes/bridgestan", subdir="R")
 ```
 
 To install a specific version of BridgeStan you can use the argument `ref`,

--- a/julia/docs/src/julia.md
+++ b/julia/docs/src/julia.md
@@ -24,7 +24,7 @@ The first time you compile a model, the BridgeStan source code for your current 
 will be downloaded as an [Artifact](https://pkgdocs.julialang.org/v1/artifacts/). If you
 prefer to use a source distribution of BridgeStan, consult the following section.
 
-Note that the system pre-requisites from the [Getting Started Guide](../getting-started.rst)
+Note that the system pre-requisites from the [Getting Started guide](../getting-started.rst)
 are still required and will not be automatically installed by this method.
 
 ### From Source
@@ -45,6 +45,11 @@ Or, since you have already downloaded the repository, you can run
 ```
 
 from the BridgeStan folder.
+
+To use the BridgeStan source you've manually downloaded instead of
+one the package will download for you, you must use
+[`set_bridgestan_path()`](BridgeStan.set_bridgestan_path!) or the `$BRIDGESTAN`
+environment variable.
 
 Note that the Julia package depends on Julia 1.8+.
 

--- a/julia/docs/src/julia.md
+++ b/julia/docs/src/julia.md
@@ -20,8 +20,8 @@ BridgeStan is registered on JuliaRegistries each release.
 ] add BridgeStan
 ```
 
-The first time you compile a model, the BridgeStan source code will be downloaded
-as an [Artifact](https://pkgdocs.julialang.org/v1/artifacts/). If you
+The first time you compile a model, the BridgeStan source code for your current version
+will be downloaded as an [Artifact](https://pkgdocs.julialang.org/v1/artifacts/). If you
 prefer to use a source distribution of BridgeStan, consult the following section.
 
 Note that the system pre-requisites from the [Getting Started Guide](../getting-started.rst)


### PR DESCRIPTION
@avehtari pointed out in #220 that the R documentation never got updated following #172 to mention that the library can now download the sources for you.

This re-writes that second and does a once-over on the other Getting Started text. It is worth us remembering to do this with Rust following #212, as well.