### PR TITLE
Clean up our usage of Bool in FFI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
 
 # only run one copy per PR
 concurrency:
@@ -270,12 +270,6 @@ jobs:
           path: ./test_models/
           key: ${{ hashFiles('**/*.stan', 'src/*', 'stan/src/stan/version.hpp', 'Makefile') }}-${{ matrix.os }}-v${{ env.CACHE_VERSION }}
 
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: "15.0"
-          directory: ${{ runner.temp }}/llvm
-
       - name: Set up TBB
         if: matrix.os == 'windows-latest'
         run: |
@@ -284,9 +278,6 @@ jobs:
       - name: Run rust tests
         working-directory: ./rust
         timeout-minutes: 60
-        env:
-          LIBCLANG_PATH: ${{ runner.temp }}/llvm/lib
-          LLVM_CONFIG_PATH: ${{ runner.temp }}/llvm/bin/llvm-config
         run: |
           cargo clippy
           cargo fmt --check

--- a/julia/test/model_tests.jl
+++ b/julia/test/model_tests.jl
@@ -491,7 +491,8 @@ end
     for _ = 1:R
         x = rand(BridgeStan.param_num(model))
         q = @. log(x / (1 - x)) # unconstrained scale
-        (log_density, gradient) = BridgeStan.log_density_gradient(model, q, jacobian = 0)
+        (log_density, gradient) =
+            BridgeStan.log_density_gradient(model, q, jacobian = false)
 
         p = x[1]
         @test isapprox(log_density, _bernoulli(y, p))

--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -190,7 +190,7 @@ class StanModel:
 
         self._param_num = self.stanlib.bs_param_num
         self._param_num.restype = ctypes.c_int
-        self._param_num.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
+        self._param_num.argtypes = [ctypes.c_void_p, ctypes.c_bool, ctypes.c_bool]
 
         self._param_unc_num = self.stanlib.bs_param_unc_num
         self._param_unc_num.restype = ctypes.c_int
@@ -213,8 +213,8 @@ class StanModel:
         self._param_names.restype = ctypes.c_char_p
         self._param_names.argtypes = [
             ctypes.c_void_p,
-            ctypes.c_int,
-            ctypes.c_int,
+            ctypes.c_bool,
+            ctypes.c_bool,
         ]
 
         self._param_unc_names = self.stanlib.bs_param_unc_names
@@ -225,8 +225,8 @@ class StanModel:
         self._param_constrain.restype = ctypes.c_int
         self._param_constrain.argtypes = [
             ctypes.c_void_p,
-            ctypes.c_int,
-            ctypes.c_int,
+            ctypes.c_bool,
+            ctypes.c_bool,
             double_array,
             writeable_double_array,
             ctypes.c_void_p,
@@ -255,8 +255,8 @@ class StanModel:
         self._log_density.restype = ctypes.c_int
         self._log_density.argtypes = [
             ctypes.c_void_p,
-            ctypes.c_int,
-            ctypes.c_int,
+            ctypes.c_bool,
+            ctypes.c_bool,
             double_array,
             ctypes.POINTER(ctypes.c_double),
             star_star_char,
@@ -266,8 +266,8 @@ class StanModel:
         self._log_density_gradient.restype = ctypes.c_int
         self._log_density_gradient.argtypes = [
             ctypes.c_void_p,
-            ctypes.c_int,
-            ctypes.c_int,
+            ctypes.c_bool,
+            ctypes.c_bool,
             double_array,
             ctypes.POINTER(ctypes.c_double),
             param_sized_out_array,
@@ -278,8 +278,8 @@ class StanModel:
         self._log_density_hessian.restype = ctypes.c_int
         self._log_density_hessian.argtypes = [
             ctypes.c_void_p,
-            ctypes.c_int,
-            ctypes.c_int,
+            ctypes.c_bool,
+            ctypes.c_bool,
             double_array,
             ctypes.POINTER(ctypes.c_double),
             param_sized_out_array,
@@ -291,8 +291,8 @@ class StanModel:
         self._log_density_hvp.restype = ctypes.c_int
         self._log_density_hvp.argtypes = [
             ctypes.c_void_p,
-            ctypes.c_int,
-            ctypes.c_int,
+            ctypes.c_bool,
+            ctypes.c_bool,
             double_array,
             double_array,
             ctypes.POINTER(ctypes.c_double),
@@ -352,7 +352,7 @@ class StanModel:
         :param include_gq: ``True`` to include the generated quantities.
         :return: The number of parameters.
         """
-        return self._param_num(self.model, int(include_tp), int(include_gq))
+        return self._param_num(self.model, include_tp, include_gq)
 
     def param_unc_num(self) -> int:
         """
@@ -380,7 +380,7 @@ class StanModel:
         :return: The indexed names of the parameters.
         """
         return (
-            self._param_names(self.model, int(include_tp), int(include_gq))
+            self._param_names(self.model, include_tp, include_gq)
             .decode("utf-8")
             .split(",")
         )
@@ -448,8 +448,8 @@ class StanModel:
 
         rc = self._param_constrain(
             self.model,
-            int(include_tp),
-            int(include_gq),
+            include_tp,
+            include_gq,
             theta_unc,
             out,
             rng_ptr,
@@ -550,8 +550,8 @@ class StanModel:
         err = ctypes.c_char_p()
         rc = self._log_density(
             self.model,
-            int(propto),
-            int(jacobian),
+            propto,
+            jacobian,
             theta_unc,
             ctypes.byref(lp),
             ctypes.byref(err),
@@ -597,8 +597,8 @@ class StanModel:
 
         rc = self._log_density_gradient(
             self.model,
-            int(propto),
-            int(jacobian),
+            propto,
+            jacobian,
             theta_unc,
             ctypes.byref(lp),
             out,
@@ -654,8 +654,8 @@ class StanModel:
 
         rc = self._log_density_hessian(
             self.model,
-            int(propto),
-            int(jacobian),
+            propto,
+            jacobian,
             theta_unc,
             ctypes.byref(lp),
             out_grad,
@@ -701,8 +701,8 @@ class StanModel:
 
         rc = self._log_density_hvp(
             self.model,
-            int(propto),
-            int(jacobian),
+            propto,
+            jacobian,
             theta_unc,
             v,
             ctypes.byref(lp),

--- a/src/bridgestanR.cpp
+++ b/src/bridgestanR.cpp
@@ -23,14 +23,14 @@ void bs_model_info_R(bs_model** model, char const** info_out) {
 }
 void bs_param_names_R(bs_model** model, int* include_tp, int* include_gq,
                       char const** names_out) {
-  *names_out = bs_param_names(*model, *include_tp, *include_gq);
+  *names_out = bs_param_names(*model, (*include_tp != 0), (*include_gq != 0));
 }
 void bs_param_unc_names_R(bs_model** model, char const** names_out) {
   *names_out = bs_param_unc_names(*model);
 }
 void bs_param_num_R(bs_model** model, int* include_tp, int* include_gq,
                     int* num_out) {
-  *num_out = bs_param_num(*model, *include_tp, *include_gq);
+  *num_out = bs_param_num(*model, (*include_tp != 0), (*include_gq != 0));
 }
 void bs_param_unc_num_R(bs_model** model, int* num_out) {
   *num_out = bs_param_unc_num(*model);
@@ -38,8 +38,9 @@ void bs_param_unc_num_R(bs_model** model, int* num_out) {
 void bs_param_constrain_R(bs_model** model, int* include_tp, int* include_gq,
                           const double* theta_unc, double* theta, bs_rng** rng,
                           int* return_code, char** err_msg, void** err_ptr) {
-  *return_code = bs_param_constrain(*model, *include_tp, *include_gq, theta_unc,
-                                    theta, *rng, err_msg);
+  *return_code
+      = bs_param_constrain(*model, (*include_tp != 0), (*include_gq != 0),
+                           theta_unc, theta, *rng, err_msg);
   *err_ptr = static_cast<void*>(*err_msg);
 }
 void bs_param_unconstrain_R(bs_model** model, const double* theta,
@@ -57,24 +58,25 @@ void bs_param_unconstrain_json_R(bs_model** model, char const** json,
 void bs_log_density_R(bs_model** model, int* propto, int* jacobian,
                       const double* theta_unc, double* val, int* return_code,
                       char** err_msg, void** err_ptr) {
-  *return_code
-      = bs_log_density(*model, *propto, *jacobian, theta_unc, val, err_msg);
+  *return_code = bs_log_density(*model, (*propto != 0), (*jacobian != 0),
+                                theta_unc, val, err_msg);
   *err_ptr = static_cast<void*>(*err_msg);
 }
 void bs_log_density_gradient_R(bs_model** model, int* propto, int* jacobian,
                                const double* theta_unc, double* val,
                                double* grad, int* return_code, char** err_msg,
                                void** err_ptr) {
-  *return_code = bs_log_density_gradient(*model, *propto, *jacobian, theta_unc,
-                                         val, grad, err_msg);
+  *return_code = bs_log_density_gradient(
+      *model, (*propto != 0), (*jacobian != 0), theta_unc, val, grad, err_msg);
   *err_ptr = static_cast<void*>(*err_msg);
 }
 void bs_log_density_hessian_R(bs_model** model, int* propto, int* jacobian,
                               const double* theta_unc, double* val,
                               double* grad, double* hess, int* return_code,
                               char** err_msg, void** err_ptr) {
-  *return_code = bs_log_density_hessian(*model, *propto, *jacobian, theta_unc,
-                                        val, grad, hess, err_msg);
+  *return_code
+      = bs_log_density_hessian(*model, (*propto != 0), (*jacobian != 0),
+                               theta_unc, val, grad, hess, err_msg);
   *err_ptr = static_cast<void*>(*err_msg);
 }
 void bs_log_density_hessian_vector_product_R(bs_model** model, int* propto,
@@ -84,7 +86,8 @@ void bs_log_density_hessian_vector_product_R(bs_model** model, int* propto,
                                              double* Hvp, int* return_code,
                                              char** err_msg, void** err_ptr) {
   *return_code = bs_log_density_hessian_vector_product(
-      *model, *propto, *jacobian, theta_unc, vector, val, Hvp, err_msg);
+      *model, (*propto != 0), (*jacobian != 0), theta_unc, vector, val, Hvp,
+      err_msg);
   *err_ptr = static_cast<void*>(*err_msg);
 }
 void bs_rng_construct_R(int* seed, bs_rng** ptr_out, char** err_msg,


### PR DESCRIPTION
I recently ran into [some issues](https://github.com/JuliaLang/julia/issues/54257) which originated from improperly passing `bool` arguments as `Int32`s. 

This appears to be fine on most architectures, especially in our case where they're small functions passing arguments on the stack, but it still seemed like something worth fixing up.

I also was made aware of the much more compact `@ccall` Julia macro that makes it much clearer what types are associated with which arguments