### PR TITLE
R: Warn if error is too long to print properly

### DIFF
--- a/R/R/bridgestan.R
+++ b/R/R/bridgestan.R
@@ -347,6 +347,9 @@ handle_error <- function(lib_name, err_msg, err_ptr, function_name) {
     return(paste("Unknown error in", function_name))
   } else {
     .C("bs_free_error_msg_R", as.raw(err_ptr), PACKAGE = lib_name)
+    if (getOption("warning.length") < nchar(err_msg)) {
+      warning("BridgeStan error message too long to fully display. Consider increasing options(warning.length)")
+    }
     return(err_msg)
   }
 }

--- a/R/R/compile.R
+++ b/R/R/compile.R
@@ -47,13 +47,13 @@ get_bridgestan_path <- function() {
                 "environment variable, downloading version ", packageVersion("bridgestan"),
                 " to ", path))
             get_bridgestan_src()
+            print("Done!")
         })
         num_files <- length(list.files(HOME_BRIDGESTAN))
         if (num_files >= 5) {
             warning(paste0("Found ", num_files, " different versions of BridgeStan in ",
                 HOME_BRIDGESTAN, ". Consider deleting old versions to save space."))
         }
-        print("Done!")
     }
 
     return(path)
@@ -101,8 +101,13 @@ compile_model <- function(stan_file, stanc_args = NULL, make_args = NULL) {
     })
     res_attrs <- attributes(res)
     if ("status" %in% names(res_attrs) && res_attrs$status != 0) {
-        stop(paste0("Compilation failed with error code ", res_attrs$status, "\noutput:\n",
-            paste(res, collapse = "\n")))
+        error_msg <- paste0("Compilation failed with error code ", res_attrs$status,
+            "\noutput:\n", paste(res, collapse = "\n"))
+
+        if (getOption("warning.length") < nchar(err_msg)) {
+            warning("BridgeStan error message too long to fully display. Consider increasing options(warning.length)")
+        }
+        stop(error_msg)
     }
 
     return(output)

--- a/R/R/compile.R
+++ b/R/R/compile.R
@@ -104,7 +104,7 @@ compile_model <- function(stan_file, stanc_args = NULL, make_args = NULL) {
         error_msg <- paste0("Compilation failed with error code ", res_attrs$status,
             "\noutput:\n", paste(res, collapse = "\n"))
 
-        if (getOption("warning.length") < nchar(err_msg)) {
+        if (getOption("warning.length") < nchar(error_msg)) {
             warning("BridgeStan error message too long to fully display. Consider increasing options(warning.length)")
         }
         stop(error_msg)


### PR DESCRIPTION
R has a [maximum length for warnings/error messages,](https://stackoverflow.com/questions/50387667/how-to-prevent-truncation-of-error-messages-in-r) controlled by `options(warning.length)`. This has lead to some confusion before, see [1](https://discourse.mc-stan.org/t/post-hoc-prediction-use-samples-from-fitted-model-in-a-prediction-task/34319/29?u=wardbrian), [2](https://discourse.mc-stan.org/t/various-compilation-problems-with-various-interfaces/34155/7?u=wardbrian)

This adds a check to places where we know there could be long error messages generated by BridgeStan and adds a warning if we know they will be truncated. This warning is reported alongside the error and should help people debug