### PR TITLE
Support for USER_HEADER in build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 c-example/example
 c-example/example_static
 *.exe
+make/local
+
 
 # Rust
 rust/target/

--- a/Makefile
+++ b/Makefile
@@ -86,23 +86,22 @@ endif
 docs:
 	$(MAKE) -C docs/ html
 
+# build all test models at once
+ALL_TEST_MODEL_NAMES = $(patsubst $(BS_ROOT)/test_models/%/, %, $(sort $(dir $(wildcard $(BS_ROOT)/test_models/*/))))
+# these are for compilation testing in the interfaces
+SKIPPED_TEST_MODEL_NAMES = syntax_error external
+TEST_MODEL_NAMES := $(filter-out $(SKIPPED_TEST_MODEL_NAMES), $(ALL_TEST_MODEL_NAMES))
+TEST_MODEL_LIBS = $(join $(addprefix $(BS_ROOT)/test_models/, $(TEST_MODEL_NAMES)), $(addsuffix _model.so, $(addprefix /, $(TEST_MODEL_NAMES))))
+
+.PHONY: test_models
+test_models: $(TEST_MODEL_LIBS)
+
 .PHONY: clean
 clean:
 	$(RM) $(SRC)/*.o
 	$(RM) test_models/**/*.so
-	$(RM) test_models/**/*.hpp
+	$(RM) $(join $(addprefix $(BS_ROOT)/test_models/, $(TEST_MODEL_NAMES)), $(addsuffix .hpp, $(addprefix /, $(TEST_MODEL_NAMES))))
 	$(RM) bin/stanc$(EXE)
-
-
-# build all test models at once
-TEST_MODEL_NAMES = $(patsubst $(BS_ROOT)/test_models/%/, %, $(sort $(dir $(wildcard $(BS_ROOT)/test_models/*/))))
-# these are for compilation testing in the interfaces
-SKIPPED_TEST_MODEL_NAMES = syntax_error external
-TEST_MODEL_NAMES := $(filter-out $(SKIPPED_TEST_MODEL_NAMES), $(TEST_MODEL_NAMES))
-TEST_MODEL_LIBS = $(join $(addprefix test_models/, $(TEST_MODEL_NAMES)), $(addsuffix _model.so, $(addprefix /, $(TEST_MODEL_NAMES))))
-
-.PHONY: test_models
-test_models: $(TEST_MODEL_LIBS)
 
 .PHONY: stan-update stan-update-version
 stan-update:

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -165,6 +165,19 @@ to set :makevar:`CPPFLAGS` in :file:`make/local`:
 
     CPPFLAGS+=-DSTAN_MATH_CONSTRAINT_TOLERANCE=1e-5
 
+
+Using External C++ Code
+_______________________
+
+BridgeStan supports the same `capability to plug in external C++ code as CmdStan <https://mc-stan.org/docs/cmdstan-guide/external_code.html>`_.
+
+Namely, you can declare a function in your Stan model and then define it in a separate C++ file.
+This requires passing the ``--allow-undefined`` flag to the Stan compiler when building your model.
+The :makevar:`USER_HEADER` variable must point to the C++ file containing the function definition.
+By default, this will be the file :file:`user_header.hpp` in the same directory as the Stan model.
+
+For a more complete example, consult the `CmdStan documentation <https://mc-stan.org/docs/cmdstan-guide/external_code.html>`_.
+
 Using Older Stan Versions
 __________________________
 

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -24,6 +24,25 @@ def test_compile_good():
     assert "STAN_THREADS=true" in model.model_info()
 
 
+def test_compile_user_header():
+    stanfile = STAN_FOLDER / "external" / "external.stan"
+    lib = bs.compile.generate_so_name(stanfile)
+    lib.unlink(missing_ok=True)
+
+    with pytest.raises(RuntimeError, match=r"declared without specifying a definition"):
+        bs.compile_model(stanfile)
+
+    with pytest.raises(RuntimeError, match=r"USER_HEADER"):
+        bs.compile_model(stanfile, stanc_args=["--allow-undefined"])
+
+    header = stanfile.parent / "make_odds.hpp"
+    res = bs.compile_model(
+        stanfile, stanc_args=["--allow-undefined"], make_args=[f"USER_HEADER={header}"]
+    )
+    assert lib.samefile(res)
+    assert lib.exists()
+
+
 def test_compile_bad_ext():
     not_stanfile = STAN_FOLDER / "multi" / "multi.data.json"
     with pytest.raises(ValueError, match=r".stan"):

--- a/rust/tests/loading.rs
+++ b/rust/tests/loading.rs
@@ -8,6 +8,8 @@ use std::{
 
 use bridgestan::Model;
 
+const EXCLUDED_MODELS: [&str; 4] = ["logistic", "regression", "syntax_error", "external"];
+
 #[test]
 fn create_all_serial() {
     let base = model_dir();
@@ -15,7 +17,7 @@ fn create_all_serial() {
         let path = path.unwrap().path();
         let name = path.file_name().unwrap().to_str().unwrap();
 
-        if (name == "logistic") | (name == "regression") | (name == "syntax_error") {
+        if EXCLUDED_MODELS.contains(&name) {
             continue;
         }
 
@@ -44,7 +46,7 @@ fn create_all_late_drop_fwd() {
 
     let handles: Vec<_> = names
         .into_iter()
-        .filter(|name| (name != "logistic") & (name != "regression") & (name != "syntax_error"))
+        .filter(|name| !EXCLUDED_MODELS.contains(&name.as_str()))
         .map(|name| {
             let (lib, data) = get_model(&name);
             let Ok(model) = Model::new(&lib, data.as_ref(), 42) else {
@@ -74,7 +76,7 @@ fn create_all_thread_serial() {
 
     names.into_iter().for_each(|name| {
         spawn(move || {
-            if (&name == "logistic") | (&name == "regression") | (&name == "syntax_error") {
+            if EXCLUDED_MODELS.contains(&name.as_str()) {
                 return;
             }
 
@@ -108,7 +110,7 @@ fn create_all_parallel() {
         .into_iter()
         .map(|name| {
             spawn(move || {
-                if (&name == "logistic") | (&name == "regression") | (&name == "syntax_error") {
+                if EXCLUDED_MODELS.contains(&name.as_str()) {
                     return;
                 }
 

--- a/test_models/external/external.stan
+++ b/test_models/external/external.stan
@@ -1,0 +1,18 @@
+functions {
+  real make_odds(data real theta);
+}
+data {
+  int<lower=0> N;
+  array[N] int<lower=0, upper=1> y;
+}
+parameters {
+  real<lower=0, upper=1> theta;
+}
+model {
+  theta ~ beta(1, 1); // uniform prior on interval 0, 1
+  y ~ bernoulli(theta);
+}
+generated quantities {
+  real odds;
+  odds = make_odds(theta);
+}

--- a/test_models/external/make_odds.hpp
+++ b/test_models/external/make_odds.hpp
@@ -1,0 +1,5 @@
+#include <ostream>
+
+double make_odds(const double& theta, std::ostream *pstream__) {
+  return theta / (1 - theta);
+}


### PR DESCRIPTION
This ports the portion of the CmdStan makefile that allows for easier inclusion of external C++ functions:
https://mc-stan.org/docs/cmdstan-guide/external_code.html

Essentially, if the `--allow-undefined` option is passed to stanc3, we then look for a header file to be included during compilation. By default this is `user_header.hpp` in the same folder as the Stan model, but it can be changed by setting `USER_HEADER`.

I'm not sure where is the best place to slot in documentation for this. 