### PR TITLE
Add a download flag to get_bridgestan_path

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -12,6 +12,7 @@ RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE, r6 = TRUE)
 Suggests:
     testthat (>= 3.0.0)
+    withr (>= 3.0.0)
 Imports:
     R6 (>= 2.4.0)
 Config/testthat/edition: 3

--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -11,7 +11,7 @@ Encoding: UTF-8
 RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE, r6 = TRUE)
 Suggests:
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
     withr (>= 3.0.0)
 Imports:
     R6 (>= 2.4.0)

--- a/R/R/compile.R
+++ b/R/R/compile.R
@@ -31,9 +31,10 @@ set_bridgestan_path <- function(path) {
 #' variable `BRIDGESTAN`.
 #'
 #' If there is no path set and the argument `download` is TRUE,
-#' this function will download a matching version of BridgeStan
-#' to a folder called `.bridgestan` in the user's home directory
-#' if one is not already present.
+#' this function will download a copy of the BridgeStan source code
+#' for the currently installed version under a folder called
+#' `.bridgestan` in the user's home directory if one is not already
+#' present.
 #'
 #' @seealso [set_bridgestan_path()]
 get_bridgestan_path <- function(download=TRUE) {

--- a/R/R/compile.R
+++ b/R/R/compile.R
@@ -30,24 +30,31 @@ set_bridgestan_path <- function(path) {
 #' By default this is set to the value of the environment
 #' variable `BRIDGESTAN`.
 #'
-#' If there is no path set, this function will download
-#' a matching version of BridgeStan to a folder called
-#' `.bridgestan` in the user's home directory.
+#' If there is no path set and the argument `download` is TRUE,
+#' this function will download a matching version of BridgeStan
+#' to a folder called `.bridgestan` in the user's home directory
+#' if one is not already present.
 #'
 #' @seealso [set_bridgestan_path()]
-get_bridgestan_path <- function() {
+get_bridgestan_path <- function(download=TRUE) {
     # try to get from environment
     path <- Sys.getenv("BRIDGESTAN", unset = "")
     if (path == "") {
-        path <- CURRENT_BRIDGESTAN
-        tryCatch({
+        path <- tryCatch({
+            path <- CURRENT_BRIDGESTAN
             verify_bridgestan_path(path)
+            path
         }, error = function(e) {
+            if (!download) {
+                print("BridgeStan not found at location specified by $BRIDGESTAN environment variable.")
+                return("")
+            }
             print(paste0("BridgeStan not found at location specified by $BRIDGESTAN ",
                 "environment variable, downloading version ", packageVersion("bridgestan"),
                 " to ", path))
             get_bridgestan_src()
             print("Done!")
+            path
         })
         num_files <- length(list.files(HOME_BRIDGESTAN))
         if (num_files >= 5) {

--- a/R/man/get_bridgestan_path.Rd
+++ b/R/man/get_bridgestan_path.Rd
@@ -12,9 +12,10 @@ variable \code{BRIDGESTAN}.
 }
 \details{
 If there is no path set and the argument \code{download} is TRUE,
-this function will download a matching version of BridgeStan
-to a folder called \code{.bridgestan} in the user's home directory
-if one is not already present.
+this function will download a copy of the BridgeStan source code
+for the currently installed version under a folder called
+\code{.bridgestan} in the user's home directory if one is not already
+present.
 }
 \seealso{
 \code{\link[=set_bridgestan_path]{set_bridgestan_path()}}

--- a/R/man/get_bridgestan_path.Rd
+++ b/R/man/get_bridgestan_path.Rd
@@ -4,16 +4,17 @@
 \alias{get_bridgestan_path}
 \title{Get the path to BridgeStan.}
 \usage{
-get_bridgestan_path()
+get_bridgestan_path(download = TRUE)
 }
 \description{
 By default this is set to the value of the environment
 variable \code{BRIDGESTAN}.
 }
 \details{
-If there is no path set, this function will download
-a matching version of BridgeStan to a folder called
-\code{.bridgestan} in the user's home directory.
+If there is no path set and the argument \code{download} is TRUE,
+this function will download a matching version of BridgeStan
+to a folder called \code{.bridgestan} in the user's home directory
+if one is not already present.
 }
 \seealso{
 \code{\link[=set_bridgestan_path]{set_bridgestan_path()}}

--- a/R/tests/testthat/test_download.R
+++ b/R/tests/testthat/test_download.R
@@ -1,0 +1,15 @@
+
+test_that("downloading source code works", {
+
+    withr::with_envvar(c("BRIDGESTAN" = ""), {
+        existing <- get_bridgestan_path(download = FALSE)
+
+        if (existing != "") {
+            unlink(existing, recursive = TRUE)
+        }
+
+        expect_equal(get_bridgestan_path(download = FALSE), "")
+        verify_bridgestan_path(get_bridgestan_path(download = TRUE))
+        verify_bridgestan_path(get_bridgestan_path(download = FALSE))
+    })
+})

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -526,7 +526,7 @@ Run BridgeStan’s Makefile on a `.stan` file, creating the `.so` used by StanMo
 This function checks that the path to BridgeStan is valid and will error if it is not. This can be set with [`set_bridgestan_path!()`](julia.md#BridgeStan.set_bridgestan_path!).
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L73-L86' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L74-L87' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.get_bridgestan_path' href='#BridgeStan.get_bridgestan_path'>#</a>
 **`BridgeStan.get_bridgestan_path`** &mdash; *Function*.
@@ -541,12 +541,12 @@ Return the path the the BridgeStan directory.
 
 If the environment variable `$BRIDGESTAN` is set, this will be returned.
 
-If `$BRIDGESTAN` is not set and `download` is true, this function downloads a matching version of BridgeStan under a folder called `.bridgestan` in the user's home directory if one is not already present.
+If `$BRIDGESTAN` is not set and `download` is true, this function downloads a copy of the BridgeStan source code for the currently installed version under a folder called `.bridgestan` in the user's home directory if one is not already present.
 
 See [`set_bridgestan_path!()`](julia.md#BridgeStan.set_bridgestan_path!) to set the path from within Julia.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L19-L31' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L19-L32' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.set_bridgestan_path!' href='#BridgeStan.set_bridgestan_path!'>#</a>
 **`BridgeStan.set_bridgestan_path!`** &mdash; *Function*.
@@ -560,5 +560,5 @@ set_bridgestan_path!(path)
 Set the path BridgeStan.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L62-L66' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L63-L67' class='documenter-source'>source</a><br>
 

--- a/docs/languages/julia.md
+++ b/docs/languages/julia.md
@@ -526,7 +526,7 @@ Run BridgeStan’s Makefile on a `.stan` file, creating the `.so` used by StanMo
 This function checks that the path to BridgeStan is valid and will error if it is not. This can be set with [`set_bridgestan_path!()`](julia.md#BridgeStan.set_bridgestan_path!).
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L65-L78' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L73-L86' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.get_bridgestan_path' href='#BridgeStan.get_bridgestan_path'>#</a>
 **`BridgeStan.get_bridgestan_path`** &mdash; *Function*.
@@ -534,17 +534,19 @@ This function checks that the path to BridgeStan is valid and will error if it i
 
 
 ```julia
-get_bridgestan_path() -> String
+get_bridgestan_path(;download=true) -> String
 ```
 
 Return the path the the BridgeStan directory.
 
-If the environment variable `BRIDGESTAN` is set, this will be returned. Otherwise, this function downloads a matching version of BridgeStan under a folder called `.bridgestan` in the user's home directory.
+If the environment variable `$BRIDGESTAN` is set, this will be returned.
+
+If `$BRIDGESTAN` is not set and `download` is true, this function downloads a matching version of BridgeStan under a folder called `.bridgestan` in the user's home directory if one is not already present.
 
 See [`set_bridgestan_path!()`](julia.md#BridgeStan.set_bridgestan_path!) to set the path from within Julia.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L19-L29' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L19-L31' class='documenter-source'>source</a><br>
 
 <a id='BridgeStan.set_bridgestan_path!' href='#BridgeStan.set_bridgestan_path!'>#</a>
 **`BridgeStan.set_bridgestan_path!`** &mdash; *Function*.
@@ -558,5 +560,5 @@ set_bridgestan_path!(path)
 Set the path BridgeStan.
 
 
-<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L54-L58' class='documenter-source'>source</a><br>
+<a target='_blank' href='https://github.com/roualdes/bridgestan/blob/main/julia/src/compile.jl#L62-L66' class='documenter-source'>source</a><br>
 

--- a/julia/src/compile.jl
+++ b/julia/src/compile.jl
@@ -4,7 +4,7 @@ function get_make()
 end
 
 
-function validate_stan_dir(path::AbstractString)
+function verify_bridgestan_path(path::AbstractString)
     if !isdir(path)
         error("Path does not exist!\n$path")
     end
@@ -24,17 +24,18 @@ Return the path the the BridgeStan directory.
 If the environment variable `\$BRIDGESTAN` is set, this will be returned.
 
 If `\$BRIDGESTAN` is not set and `download` is true, this function downloads
-a matching version of BridgeStan under a folder called `.bridgestan` in the
-user's home directory if one is not already present.
+a copy of the BridgeStan source code for the currently installed version under
+a folder called `.bridgestan` in the user's home directory if one is not already
+present.
 
 See [`set_bridgestan_path!()`](@ref) to set the path from within Julia.
 """
 function get_bridgestan_path(; download::Bool = true)
     path = get(ENV, "BRIDGESTAN", "")
     if path == ""
-        path = CURRENT_BRIDGESTAN
         try
-            validate_stan_dir(path)
+            path = CURRENT_BRIDGESTAN
+            verify_bridgestan_path(path)
         catch
             if !download
                 println(
@@ -65,7 +66,7 @@ end
 Set the path BridgeStan.
 """
 function set_bridgestan_path!(path::AbstractString)
-    validate_stan_dir(path)
+    verify_bridgestan_path(path)
     ENV["BRIDGESTAN"] = path
 end
 
@@ -90,7 +91,7 @@ function compile_model(
     make_args::AbstractVector{String} = String[],
 )
     bridgestan = get_bridgestan_path()
-    validate_stan_dir(bridgestan)
+    verify_bridgestan_path(bridgestan)
 
     if !isfile(stan_file)
         throw(SystemError("Stan file not found: $stan_file"))

--- a/julia/src/compile.jl
+++ b/julia/src/compile.jl
@@ -17,23 +17,31 @@ end
 
 
 """
-    get_bridgestan_path() -> String
+    get_bridgestan_path(;download=true) -> String
 
 Return the path the the BridgeStan directory.
 
-If the environment variable `BRIDGESTAN` is set, this will be returned.
-Otherwise, this function downloads a matching version of BridgeStan under
-a folder called `.bridgestan` in the user's home directory.
+If the environment variable `\$BRIDGESTAN` is set, this will be returned.
+
+If `\$BRIDGESTAN` is not set and `download` is true, this function downloads
+a matching version of BridgeStan under a folder called `.bridgestan` in the
+user's home directory if one is not already present.
 
 See [`set_bridgestan_path!()`](@ref) to set the path from within Julia.
 """
-function get_bridgestan_path()
+function get_bridgestan_path(; download::Bool = true)
     path = get(ENV, "BRIDGESTAN", "")
     if path == ""
         path = CURRENT_BRIDGESTAN
         try
             validate_stan_dir(path)
         catch
+            if !download
+                println(
+                    "BridgeStan not found at location specified by \$BRIDGESTAN environment variable",
+                )
+                return ""
+            end
             println(
                 "BridgeStan not found at location specified by \$BRIDGESTAN " *
                 "environment variable, downloading version $pkg_version to $path",

--- a/julia/test/util_tests.jl
+++ b/julia/test/util_tests.jl
@@ -28,6 +28,16 @@ end
 
 @testset "download" begin
     withenv("BRIDGESTAN" => nothing) do
+        existing = BridgeStan.get_bridgestan_path(download = false)
+        if existing != "" && isdir(existing)
+            rm(existing; recursive = true)
+        end
+
+        # first call - download doesn't occur
+        @test "" == BridgeStan.get_bridgestan_path(download = false)
+        # download occurs
         BridgeStan.validate_stan_dir(BridgeStan.get_bridgestan_path())
+        # download doesn't occur, returns path from 2nd call
+        BridgeStan.validate_stan_dir(BridgeStan.get_bridgestan_path(download = false))
     end
 end

--- a/julia/test/util_tests.jl
+++ b/julia/test/util_tests.jl
@@ -36,8 +36,8 @@ end
         # first call - download doesn't occur
         @test "" == BridgeStan.get_bridgestan_path(download = false)
         # download occurs
-        BridgeStan.validate_stan_dir(BridgeStan.get_bridgestan_path())
+        BridgeStan.verify_bridgestan_path(BridgeStan.get_bridgestan_path())
         # download doesn't occur, returns path from 2nd call
-        BridgeStan.validate_stan_dir(BridgeStan.get_bridgestan_path(download = false))
+        BridgeStan.verify_bridgestan_path(BridgeStan.get_bridgestan_path(download = false))
     end
 end

--- a/python/bridgestan/compile.py
+++ b/python/bridgestan/compile.py
@@ -43,16 +43,17 @@ def set_bridgestan_path(path: Union[str, os.PathLike]) -> None:
     os.environ["BRIDGESTAN"] = path
 
 
-def get_bridgestan_path() -> str:
+def get_bridgestan_path(download: bool = True) -> str:
     """
     Get the path to BridgeStan.
 
     By default this is set to the value of the environment
     variable ``BRIDGESTAN``.
 
-    If there is no path set, this function will download
-    a matching version of BridgeStan to a folder called
-    ``.bridgestan`` in the user's home directory.
+    If there is no path set and ``download`` is True, this
+    function will download a matching version of BridgeStan
+    to a folder called ``.bridgestan`` in the user's home
+    directory if one is not already present.
 
     See also :func:`set_bridgestan_path`
     """
@@ -62,6 +63,12 @@ def get_bridgestan_path() -> str:
             path = os.fspath(CURRENT_BRIDGESTAN)
             verify_bridgestan_path(path)
         except ValueError:
+            if not download:
+                print(
+                    "BridgeStan not found at location specified by $BRIDGESTAN environment variable"
+                )
+                return ""
+
             print(
                 "BridgeStan not found at location specified by $BRIDGESTAN "
                 f"environment variable, downloading version {__version__} to {path}"

--- a/python/bridgestan/compile.py
+++ b/python/bridgestan/compile.py
@@ -51,9 +51,10 @@ def get_bridgestan_path(download: bool = True) -> str:
     variable ``BRIDGESTAN``.
 
     If there is no path set and ``download`` is True, this
-    function will download a matching version of BridgeStan
-    to a folder called ``.bridgestan`` in the user's home
-    directory if one is not already present.
+    function will download a copy of the BridgeStan source code
+    for the currently installed version under a folder called
+    ``.bridgestan`` in the user's home directory if one is not
+    already present.
 
     See also :func:`set_bridgestan_path`
     """

--- a/python/test/test_download.py
+++ b/python/test/test_download.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from unittest import mock
 
 import bridgestan as bs
@@ -6,4 +7,10 @@ import bridgestan as bs
 
 @mock.patch.dict(os.environ, {"BRIDGESTAN": ""})
 def test_download_bridgestan():
+    if bs.download.CURRENT_BRIDGESTAN.is_dir():
+        shutil.rmtree(bs.download.CURRENT_BRIDGESTAN)
+
+    # first call doesn't download
+    assert bs.compile.get_bridgestan_path(download=False) == ""
     bs.compile.verify_bridgestan_path(bs.compile.get_bridgestan_path())
+    bs.compile.verify_bridgestan_path(bs.compile.get_bridgestan_path(download=False))


### PR DESCRIPTION
Closes #220 (@avehtari)

This adds a flag `download` to all the interfaces' `get_bridgestan_path` functions. The default is true, which is the previous behavior. Setting to `false` allows you to inspect the current value without triggering a download if it is not found. 

Internally we always use the default value, but some users may want to check if their custom installation is working without triggering a download if it isn't.