### PR TITLE
Fix rust send sync

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -300,3 +300,7 @@ jobs:
           # run all tests with feature download-bridgestan-src
           cargo test --verbose --all-features
           cargo test --verbose model_compiling -- --ignored
+      - name: Check semver for rust interface
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          manifest-path: ./rust/Cargo.toml

--- a/rust/src/bs_safe.rs
+++ b/rust/src/bs_safe.rs
@@ -25,6 +25,10 @@ pub struct StanLibrary {
     id: u64,
 }
 
+// Stan libraries are thread safe.
+unsafe impl Send for StanLibrary {}
+unsafe impl Sync for StanLibrary {}
+
 // To work around a bug where unloading a library
 // can lead to deadlocks.
 //

--- a/src/bridgestan.cpp
+++ b/src/bridgestan.cpp
@@ -5,9 +5,9 @@
 #include "callback_stream.hpp"
 #include <sstream>
 
-int bs_major_version = BRIDGESTAN_MAJOR;
-int bs_minor_version = BRIDGESTAN_MINOR;
-int bs_patch_version = BRIDGESTAN_PATCH;
+const int bs_major_version = BRIDGESTAN_MAJOR;
+const int bs_minor_version = BRIDGESTAN_MINOR;
+const int bs_patch_version = BRIDGESTAN_PATCH;
 
 bs_model* bs_model_construct(const char* data, unsigned int seed,
                              char** error_msg) {

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -34,9 +34,9 @@ typedef void (*STREAM_CALLBACK)(const char* data, size_t size);
  * @note These were not available pre-2.0.0, so their absence
  * implies the library is in the 1.0.x series
  */
-BS_PUBLIC extern int bs_major_version;
-BS_PUBLIC extern int bs_minor_version;
-BS_PUBLIC extern int bs_patch_version;
+BS_PUBLIC extern const int bs_major_version;
+BS_PUBLIC extern const int bs_minor_version;
+BS_PUBLIC extern const int bs_patch_version;
 
 /**
  * Construct an instance of a model wrapper.


### PR DESCRIPTION
Fixes #258 by explicitly marking the StanLibrary as Send + Sync.

This also adds an entry to the github workflow, which should automatically find most backward incompatible changes that break semver.