### PR TITLE
Fix log_density calls not being thread safe

### DIFF
--- a/src/model_rng.cpp
+++ b/src/model_rng.cpp
@@ -253,8 +253,11 @@ void bs_model::log_density(bool propto, bool jacobian, const double* theta_unc,
   Eigen::VectorXd params_unc = Eigen::VectorXd::Map(theta_unc, param_unc_num_);
 
   if (propto) {
-    // need to have vars, otherwise the result is 0 since everything is
-    // treated as a constant
+// need to have vars, otherwise the result is 0 since everything is
+// treated as a constant
+#ifdef STAN_THREADS
+  static thread_local stan::math::ChainableStack thread_instance;
+#endif
     try {
       Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1> params_unc_var(
           params_unc);

--- a/src/model_rng.cpp
+++ b/src/model_rng.cpp
@@ -27,15 +27,8 @@
 // ensure a thread-local ChainableStack exists. This macro is invoked in
 // each function that could need it.
 #ifdef STAN_THREADS
-// minor optimization: if GNU's __thread is available, prefer it to thread_local
-// this is also done by Stan internally.
-#ifdef __GNUC__
-#define BRIDGESTAN_PREPARE_AD_FOR_THREADING() \
-  static __thread stan::math::ChainableStack thread_instance
-#else
 #define BRIDGESTAN_PREPARE_AD_FOR_THREADING() \
   static thread_local stan::math::ChainableStack thread_instance
-#endif
 #else
 #define BRIDGESTAN_PREPARE_AD_FOR_THREADING()
 #endif


### PR DESCRIPTION
Closes #272.

This was a simple oversight, similar to the memory leak in #180: `log_density(propto=True)` requires using the autodiff stack, which means we need to take the same precautions as the other log density functions when using it in multiple threads. Namely, at least one `thread_local stan::math::ChainableStack` must have been instantiated on each thread before use. 

This moves the code we had in each function that did this before into one macro, and adds it to the `propto` branch of `log_density()`.