### PR TITLE
Maybe: clean up error handling

### DIFF
--- a/src/bridgestan.cpp
+++ b/src/bridgestan.cpp
@@ -3,10 +3,12 @@
 #include "rng.hpp"
 #include "callback_stream.hpp"
 #include "version.hpp"
+#include "util.hpp"
 
 #include "bridgestanR.cpp"
 
-#include <sstream>
+
+using bridgestan::handle_errors;
 
 const int bs_major_version = BRIDGESTAN_MAJOR;
 const int bs_minor_version = BRIDGESTAN_MINOR;
@@ -14,27 +16,8 @@ const int bs_patch_version = BRIDGESTAN_PATCH;
 
 bs_model* bs_model_construct(const char* data, unsigned int seed,
                              char** error_msg) {
-  try {
-    return new bs_model(data, seed);
-  } catch (const std::exception& e) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "construct(" << (data == nullptr ? "NULL" : data) << ", " << seed
-            << ")"
-            << " failed with exception: " << e.what() << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  } catch (...) {
-    if (error_msg) {
-      std::stringstream error;
-
-      error << "construct(" << (data == nullptr ? "NULL" : data) << ", " << seed
-            << ")"
-            << " failed with unknown exception" << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  }
-  return nullptr;
+  return handle_errors("construct", error_msg,
+                       [&]() { return new bs_model(data, seed); });
 }
 
 void bs_model_destruct(bs_model* m) { delete (m); }
@@ -63,7 +46,7 @@ int bs_param_unc_num(const bs_model* m) { return m->param_unc_num(); }
 int bs_param_constrain(const bs_model* m, bool include_tp, bool include_gq,
                        const double* theta_unc, double* theta, bs_rng* rng,
                        char** error_msg) {
-  try {
+  return handle_errors("param_constrain", error_msg, [&]() {
     if (rng == nullptr) {
       // If RNG is not provided (e.g., we are not using include_gq), use a dummy
       // RNG.
@@ -77,135 +60,49 @@ int bs_param_constrain(const bs_model* m, bool include_tp, bool include_gq,
     } else
       m->param_constrain(include_tp, include_gq, theta_unc, theta, rng->rng_);
     return 0;
-  } catch (const std::exception& e) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "param_constrain() failed with exception: " << e.what()
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  } catch (...) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "param_constrain() failed with unknown exception" << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  }
-  return 1;
+  });
 }
 
 int bs_param_unconstrain(const bs_model* m, const double* theta,
                          double* theta_unc, char** error_msg) {
-  try {
+  return handle_errors("param_unconstrain", error_msg, [&]() {
     m->param_unconstrain(theta, theta_unc);
     return 0;
-  } catch (const std::exception& e) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "param_unconstrain() failed with exception: " << e.what()
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  } catch (...) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "param_unconstrain() failed with unknown exception" << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  }
-  return -1;
+  });
 }
 
 int bs_param_unconstrain_json(const bs_model* m, const char* json,
                               double* theta_unc, char** error_msg) {
-  try {
+  return handle_errors("param_unconstrain_json", error_msg, [&]() {
     m->param_unconstrain_json(json, theta_unc);
     return 0;
-  } catch (const std::exception& e) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "param_unconstrain_json() failed with exception: " << e.what()
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  } catch (...) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "param_unconstrain_json() failed with unknown exception"
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  }
-  return -1;
+  });
 }
 
 int bs_log_density(const bs_model* m, bool propto, bool jacobian,
                    const double* theta_unc, double* val, char** error_msg) {
-  try {
+  return handle_errors("log_density", error_msg, [&]() {
     m->log_density(propto, jacobian, theta_unc, val);
     return 0;
-  } catch (const std::exception& e) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "log_density() failed with exception: " << e.what() << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  } catch (...) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "log_density() failed with unknown exception" << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  }
-  return -1;
+  });
 }
 
 int bs_log_density_gradient(const bs_model* m, bool propto, bool jacobian,
                             const double* theta_unc, double* val, double* grad,
                             char** error_msg) {
-  try {
+  return handle_errors("log_density_gradient", error_msg, [&]() {
     m->log_density_gradient(propto, jacobian, theta_unc, val, grad);
     return 0;
-  } catch (const std::exception& e) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "log_density_gradient() failed with exception: " << e.what()
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  } catch (...) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "log_density_gradient() failed with unknown exception"
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  }
-  return -1;
+  });
 }
 
 int bs_log_density_hessian(const bs_model* m, bool propto, bool jacobian,
                            const double* theta_unc, double* val, double* grad,
                            double* hessian, char** error_msg) {
-  try {
+  return handle_errors("log_density_hessian", error_msg, [&]() {
     m->log_density_hessian(propto, jacobian, theta_unc, val, grad, hessian);
     return 0;
-  } catch (const std::exception& e) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "log_density_hessian() failed with exception: " << e.what()
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  } catch (...) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "log_density_hessian() failed with unknown exception"
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  }
-  return -1;
+  });
 }
 
 int bs_log_density_hessian_vector_product(const bs_model* m, bool propto,
@@ -213,48 +110,16 @@ int bs_log_density_hessian_vector_product(const bs_model* m, bool propto,
                                           const double* theta_unc,
                                           const double* v, double* val,
                                           double* Hvp, char** error_msg) {
-  try {
+  return handle_errors("log_density_hessian_vector_product", error_msg, [&]() {
     m->log_density_hessian_vector_product(propto, jacobian, theta_unc, v, val,
                                           Hvp);
     return 0;
-  } catch (const std::exception& e) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "log_density_hessian_vector_product() failed with exception: "
-            << e.what() << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  } catch (...) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "log_density_hessian_vector_product() failed with unknown "
-               "exception"
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  }
-  return -1;
+  });
 }
 
 bs_rng* bs_rng_construct(unsigned int seed, char** error_msg) {
-  try {
-    return new bs_rng(seed);
-  } catch (const std::exception& e) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "construct_rng() failed with exception: " << e.what()
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  } catch (...) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "construct_rng() failed with unknown exception" << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  }
-
-  return nullptr;
+  return handle_errors("construct_rng", error_msg,
+                       [&]() { return new bs_rng(seed); });
 }
 
 void bs_rng_destruct(bs_rng* rng) { delete (rng); }
@@ -264,7 +129,7 @@ void bs_rng_destruct(bs_rng* rng) { delete (rng); }
 std::ostream* outstream = &std::cout;
 
 int bs_set_print_callback(STREAM_CALLBACK callback, char** error_msg) {
-  try {
+  return handle_errors("set_print_callback", error_msg, [&]() {
     std::ostream* old_outstream = outstream;
 
     if (callback == nullptr) {
@@ -280,13 +145,5 @@ int bs_set_print_callback(STREAM_CALLBACK callback, char** error_msg) {
       delete buf;
     }
     return 0;
-  } catch (...) {
-    if (error_msg) {
-      std::stringstream error;
-      error << "set_print_callback() failed with unknown exception"
-            << std::endl;
-      *error_msg = strdup(error.str().c_str());
-    }
-  }
-  return -1;
+  });
 }

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -29,5 +29,42 @@ inline char* to_csv(const std::vector<std::string>& names) {
   return strdup(s_c);
 }
 
+/**
+ * Convert exception-style error handling into our C output parameter
+ * style. F is always a lambda, so this code gets inlined and the function
+ * call overhead is optimized away.
+ */
+template <typename F>
+[[gnu::always_inline]] [[msvc::forceinline]]
+inline auto handle_errors(const char* name, char** error_msg, F f) {
+  try {
+    return f();
+  } catch (const std::exception& e) {
+    if (error_msg) {
+      std::stringstream error;
+      error << name << "() failed with exception: " << e.what() << std::endl;
+      *error_msg = strdup(error.str().c_str());
+    }
+  } catch (...) {
+    if (error_msg) {
+      std::stringstream error;
+      error << name << "() failed with unknown exception" << std::endl;
+      *error_msg = strdup(error.str().c_str());
+    }
+  }
+
+  // Handle the return value in the failure case, generically
+  using Result = std::invoke_result_t<F>;
+  if constexpr (std::is_same_v<Result, int>) {
+    return -1;
+  } else if constexpr (std::is_pointer_v<Result>) {
+    return static_cast<Result>(nullptr);
+  } else {
+    // if you end up here as a developer, you need to add a
+    // new case for the return type of your function
+    static_assert(std::is_same_v<Result, void>, "Unexpected return type");
+  }
+}
+
 }  // namespace bridgestan
 #endif


### PR DESCRIPTION
This removes a lot of boilerplate for our exception handling strategy by using a helper function that takes in a lambda. 

By forcing the function to inline, this actually generates more or less identical assembly: https://godbolt.org/z/3sqWoscnn

In this is too fancy, I understand 😃 