### PR TITLE
Use unique_ptr to simplify model.hpp

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -1,8 +1,6 @@
 #ifndef BRIDGESTAN_UTIL_HPP
 #define BRIDGESTAN_UTIL_HPP
 
-#include <stan/model/model_base.hpp>
-
 #include <string>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
This replaces the raw pointer usage inside our model class wrapper with unique pointers. This gets us the correct copy/move semantics automatically and removes the need for a custom destructor (the bs_model class is now a 'rule of zero' class)

I'm using `std::unique_ptr<const char>` instead of `std::string` because the former is still 8 bytes while the later is an implementation defined size, but always at least 24 bytes.  `sizeof(bs_model)` remains unchanged in this PR.