### PR TITLE
Update documentation url to roualdes.us

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We welcome contributions to the project in any form, including bug reports, bug fixes, new features, improved documentation, or improved test coverage.
 
-**Developer-specific documentation is available [as part of our online documentation](https://roualdes.github.io/bridgestan/latest/internals.html)**. Information on building BridgeStan, running tests, and developing with the project is available there.
+**Developer-specific documentation is available [as part of our online documentation](https://roualdes.us/bridgestan/latest/internals.html)**. Information on building BridgeStan, running tests, and developing with the project is available there.
 
 This document houses additional information about licensing and procedures for contributing to the project.
 

--- a/R/README.md
+++ b/R/README.md
@@ -1,6 +1,6 @@
 # bridgestan.R - The R interface to BridgeStan
 
-[View the R interface documentation online](https://roualdes.github.io/bridgestan/latest/languages/r.html)
+[View the R interface documentation online](https://roualdes.us/bridgestan/latest/languages/r.html)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # BridgeStan
 
-[![DOCS](https://img.shields.io/badge/docs-latest-blue)](https://roualdes.github.io/bridgestan/) [![DOI](https://joss.theoj.org/papers/10.21105/joss.05236/status.svg)](https://doi.org/10.21105/joss.05236) [![CI](https://github.com/roualdes/bridgestan/actions/workflows/main.yaml/badge.svg)](https://github.com/roualdes/bridgestan/actions/workflows/main.yaml)
+[![DOCS](https://img.shields.io/badge/docs-latest-blue)](https://roualdes.us/bridgestan/) [![DOI](https://joss.theoj.org/papers/10.21105/joss.05236/status.svg)](https://doi.org/10.21105/joss.05236) [![CI](https://github.com/roualdes/bridgestan/actions/workflows/main.yaml/badge.svg)](https://github.com/roualdes/bridgestan/actions/workflows/main.yaml)
 
 BridgeStan provides efficient in-memory access through Python, Julia,
 Rust, and R to the methods of a [Stan](https://mc-stan.org) model, including
@@ -19,7 +19,7 @@ models.  For an introduction to what can be coded in Stan, see the
 
 BridgeStan is currently shipping with Stan version 2.37.0
 
-Documentation is available at https://roualdes.github.io/bridgestan/
+Documentation is available at https://roualdes.us/bridgestan/
 
 
 #### Compatibility
@@ -44,7 +44,7 @@ git clone --recurse-submodules https://github.com/roualdes/bridgestan.git
 ```
 
 For a full guide on installing, configuring, and using BridgeStan, consult the
-[documentation](https://roualdes.github.io/bridgestan/latest/getting-started.html)
+[documentation](https://roualdes.us/bridgestan/latest/getting-started.html)
 
 ## Using BridgeStan
 

--- a/c-example/README.md
+++ b/c-example/README.md
@@ -1,6 +1,6 @@
 # BridgeStan from C
 
-[View the C API documentation online](https://roualdes.github.io/bridgestan/latest/languages/c-api.html).
+[View the C API documentation online](https://roualdes.us/bridgestan/latest/languages/c-api.html).
 
 This shows how one could write a C program which calls BridgeStan.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,11 +3,11 @@
 This folder hosts the top-level documentation for BridgeStan.
 
 These docs are available online at
-[https://roualdes.github.io/bridgestan/](https://roualdes.github.io/bridgestan/latest/).
+[https://roualdes.us/bridgestan/](https://roualdes.us/bridgestan/latest/).
 
 ## Building
 
-Building the documentation is documented [here](https://roualdes.github.io/bridgestan/latest/internals/documentation.html).
+Building the documentation is documented [here](https://roualdes.us/bridgestan/latest/internals/documentation.html).
 
 The main documentation can be build by running `make docs` in the top-level
 repository. `make` can also be run in this folder to produce a specific format,

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -2,91 +2,91 @@
     {
         "name": "latest",
         "version": "latest",
-        "url": "https://roualdes.github.io/bridgestan/latest/"
+        "url": "https://roualdes.us/bridgestan/latest/"
     },
     {
         "name": "v2.6.2",
         "version": "v2.6.2",
-        "url": "https://roualdes.github.io/bridgestan/v2.6.2/"
+        "url": "https://roualdes.us/bridgestan/v2.6.2/"
     },
     {
         "name": "v2.6.1",
         "version": "v2.6.1",
-        "url": "https://roualdes.github.io/bridgestan/v2.6.1/"
+        "url": "https://roualdes.us/bridgestan/v2.6.1/"
     },
     {
         "name": "v2.6.0",
         "version": "v2.6.0",
-        "url": "https://roualdes.github.io/bridgestan/v2.6.0/"
+        "url": "https://roualdes.us/bridgestan/v2.6.0/"
     },
     {
         "name": "v2.5.0",
         "version": "v2.5.0",
-        "url": "https://roualdes.github.io/bridgestan/v2.5.0/"
+        "url": "https://roualdes.us/bridgestan/v2.5.0/"
     },
     {
         "name": "v2.4.1",
         "version": "v2.4.1",
-        "url": "https://roualdes.github.io/bridgestan/v2.4.1/"
+        "url": "https://roualdes.us/bridgestan/v2.4.1/"
     },
     {
         "name": "v2.4.0",
         "version": "v2.4.0",
-        "url": "https://roualdes.github.io/bridgestan/v2.4.0/"
+        "url": "https://roualdes.us/bridgestan/v2.4.0/"
     },
     {
         "name": "v2.3.0",
         "version": "v2.3.0",
-        "url": "https://roualdes.github.io/bridgestan/v2.3.0/"
+        "url": "https://roualdes.us/bridgestan/v2.3.0/"
     },
     {
         "name": "v2.2.2",
         "version": "v2.2.2",
-        "url": "https://roualdes.github.io/bridgestan/v2.2.2/"
+        "url": "https://roualdes.us/bridgestan/v2.2.2/"
     },
     {
         "name": "v2.2.1",
         "version": "v2.2.1",
-        "url": "https://roualdes.github.io/bridgestan/v2.2.1/"
+        "url": "https://roualdes.us/bridgestan/v2.2.1/"
     },
     {
         "name": "v2.2.0",
         "version": "v2.2.0",
-        "url": "https://roualdes.github.io/bridgestan/v2.2.0/"
+        "url": "https://roualdes.us/bridgestan/v2.2.0/"
     },
     {
         "name": "v2.1.2",
         "version": "v2.1.2",
-        "url": "https://roualdes.github.io/bridgestan/v2.1.2/"
+        "url": "https://roualdes.us/bridgestan/v2.1.2/"
     },
     {
         "name": "v2.1.1",
         "version": "v2.1.1",
-        "url": "https://roualdes.github.io/bridgestan/v2.1.1/"
+        "url": "https://roualdes.us/bridgestan/v2.1.1/"
     },
     {
         "name": "v2.1.0",
         "version": "v2.1.0",
-        "url": "https://roualdes.github.io/bridgestan/v2.1.0/"
+        "url": "https://roualdes.us/bridgestan/v2.1.0/"
     },
     {
         "name": "v2.0.0",
         "version": "v2.0.0",
-        "url": "https://roualdes.github.io/bridgestan/v2.0.0/"
+        "url": "https://roualdes.us/bridgestan/v2.0.0/"
     },
     {
         "name": "v1.0.2",
         "version": "v1.0.2",
-        "url": "https://roualdes.github.io/bridgestan/v1.0.2/"
+        "url": "https://roualdes.us/bridgestan/v1.0.2/"
     },
     {
         "name": "v1.0.1",
         "version": "v1.0.1",
-        "url": "https://roualdes.github.io/bridgestan/v1.0.1/"
+        "url": "https://roualdes.us/bridgestan/v1.0.1/"
     },
     {
         "name": "v1.0.0",
         "version": "v1.0.0",
-        "url": "https://roualdes.github.io/bridgestan/v1.0.0/"
+        "url": "https://roualdes.us/bridgestan/v1.0.0/"
     }
 ]

--- a/docs/add_version.py
+++ b/docs/add_version.py
@@ -6,7 +6,7 @@ def new_version(version):
     return {
         "name": version,
         "version": version,
-        "url": f"https://roualdes.github.io/bridgestan/{version}/",
+        "url": f"https://roualdes.us/bridgestan/{version}/",
     }
 
 

--- a/julia/README.md
+++ b/julia/README.md
@@ -1,7 +1,7 @@
 
 # BridgeStan.jl - The Julia interface to BridgeStan
 
-[View the Julia interface documentation online](https://roualdes.github.io/bridgestan/latest/languages/julia.html)
+[View the Julia interface documentation online](https://roualdes.us/bridgestan/latest/languages/julia.html)
 
 ## Installation
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # bridgestan.py - The Python interface to BridgeStan
 
-[View the Python interface documentation online](https://roualdes.github.io/bridgestan/latest/languages/python.html)
+[View the Python interface documentation online](https://roualdes.us/bridgestan/latest/languages/python.html)
 
 ## Installation
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.69"
 description = "Rust interface for BridgeStan"
 repository = "https://github.com/roualdes/bridgestan"
 license = "BSD-3-Clause"
-homepage = "https://roualdes.github.io/bridgestan/latest/"
+homepage = "https://roualdes.us/bridgestan/latest/"
 
 [dependencies]
 libloading = "0.8.0"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # BridgeStan from Rust
 
-[*View the BridgeStan documentation on Github Pages*](https://roualdes.github.io/bridgestan/latest/languages/rust.html).
+[*View the BridgeStan documentation on Github Pages*](https://roualdes.us/bridgestan/latest/languages/rust.html).
 
 This is a Rust wrapper for [BridgeStan](https://github.com/roualdes/bridgestan). It
 allows users to evaluate the log likelihood and related functions for Stan models


### PR DESCRIPTION
Save our users one redirect (the old links do still work, for what it's worth)