### PR TITLE
Add thread-safe AD chain before calls to write array, constructor

### DIFF
--- a/julia/test/model_tests.jl
+++ b/julia/test/model_tests.jl
@@ -563,13 +563,13 @@ end
 
 
 
-@testset "threaded model: full" begin
+@testset "threaded model: ode_sundials" begin
 
-    model = load_test_model("full", false)
+    model = load_test_model("ode_sundials")
     nt = Threads.nthreads()
     seeds = rand(UInt32, nt)
 
-    x = [0.5] # bernoulli parameter
+    x = zeros(Float64, 0) # model is gq-only
 
     R = 1000
     out_size = BridgeStan.param_num(model; include_tp = false, include_gq = true)


### PR DESCRIPTION
I believe this should resolve #289. If you can try it out @nsiccha that would be great!

As discussed in that issue, there are a few functions in stan-math, namely the existing SUNDIALS odes (but also the laplace functions being added soon), that _always_ perform some autodiff, even if they are called with all doubles. 
These functions can appear in `transformed data` or `generated quantities`, two places we were not previously guarding with a `thread_local ChainableStack` instance.