### PR TITLE
Allow NULL for json in bs_param_initialize

### DIFF
--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -559,7 +559,7 @@ class StanModel:
     def param_initialize(
         self,
         rng: "StanRNG",
-        theta_json: Union[str, Mapping[str, Any]] = "{}",
+        theta_json: Union[str, Mapping[str, Any], None] = None,
         *,
         init_radius: float = 2.0,
         max_tries: int = 100,
@@ -598,9 +598,12 @@ class StanModel:
         dims = self.param_unc_num()
         if out is None:
             out = np.zeros(shape=dims)
-        if not isinstance(theta_json, str):
-            theta_json = stanio.dump_stan_json(theta_json)
-        chars = theta_json.encode("UTF-8")
+        if theta_json is None:
+            chars = None
+        else:
+            if not isinstance(theta_json, str):
+                theta_json = stanio.dump_stan_json(theta_json)
+            chars = theta_json.encode("UTF-8")
         err = ctypes.c_char_p()
         rc = self._param_initialize(
             self.model,

--- a/python/test/test_stanmodel.py
+++ b/python/test/test_stanmodel.py
@@ -337,6 +337,23 @@ def test_param_initialize():
     with pytest.raises(RuntimeError):
         bridge.param_initialize(rng, {"sigma": -1})
 
+    # testing various options for empty inits
+
+    carry = None  # used to test that they all get the same result for a fixed seed
+
+    for empty in [None, "", "{}", {}]:
+        rng2 = bridge.new_rng(4567)
+        empty_init = bridge.param_initialize(rng2, empty)
+
+        if carry is not None:
+            np.testing.assert_equal(carry, empty_init)
+        carry = empty_init
+
+        # basic functionality: result has finite value and gradient under the model
+        lp, grad = bridge.log_density_gradient(empty_init)
+        assert np.isfinite(lp)
+        assert np.isfinite(grad).all()
+
 
 def _log_jacobian(p):
     return np.log(p * (1 - p))

--- a/src/bridgestan.h
+++ b/src/bridgestan.h
@@ -239,7 +239,7 @@ BS_PUBLIC int bs_param_unconstrain_json(const bs_model* m, const char* json,
  * CmdStan</a>.
  *
  * @param[in] m pointer to model structure
- * @param[in] json JSON-encoded constrained parameters
+ * @param[in] json JSON-encoded constrained parameters. Can be NULL.
  * @param[in] rng Random number generator to use for the parameters not provided
  * in the JSON.
  * @param[in] init_radius The parameters not provided will be drawn uniformly

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -59,34 +59,34 @@ namespace bridgestan {
 
 using model_ptr = std::unique_ptr<stan::model::model_base>;
 
-inline model_ptr model_from_data(const char* data, unsigned int seed) {
-  // transformed data block could contain a call to a sundials ODE
-  // solver which requires AD
-  BRIDGESTAN_PREPARE_AD_FOR_THREADING();
-
+inline std::unique_ptr<stan::io::var_context> load_json(const char* data) {
   if (data == nullptr) {
-    stan::io::empty_var_context data_context;
-    return model_ptr(&new_model(data_context, seed, outstream));
+    return std::make_unique<stan::io::empty_var_context>();
   } else {
     std::string data_str(data);
     if (data_str.empty()) {
-      stan::io::empty_var_context data_context;
-      return model_ptr(&new_model(data_context, seed, outstream));
+      return std::make_unique<stan::io::empty_var_context>();
     } else {
       if (stan::io::ends_with(".json", data_str)) {
         std::ifstream in(data_str);
         if (!in.good())
           throw std::runtime_error("Cannot read input file: " + data_str);
-        stan::json::json_data data_context(in);
-        in.close();
-        return model_ptr(&new_model(data_context, seed, outstream));
+        return std::make_unique<stan::json::json_data>(in);
       } else {
         std::istringstream json(data_str);
-        stan::json::json_data data_context(json);
-        return model_ptr(&new_model(data_context, seed, outstream));
+        return std::make_unique<stan::json::json_data>(json);
       }
     }
   }
+}
+
+inline model_ptr model_from_data(const char* data, unsigned int seed) {
+  // transformed data block could contain a call to a sundials ODE
+  // solver which requires AD
+  BRIDGESTAN_PREPARE_AD_FOR_THREADING();
+
+  auto data_context = load_json(data);
+  return model_ptr(&new_model(*data_context, seed, outstream));
 }
 
 }  // namespace bridgestan
@@ -295,8 +295,7 @@ class bs_model {
    */
   void param_initialize(const char* json, stan::rng_t& rng, double init_radius,
                         int max_tries, bool jacobian, double* theta_unc) const {
-    std::stringstream in(json);
-    stan::json::json_data inits_context(in);
+    auto inits_context = bridgestan::load_json(json);
     stan::callbacks::writer dummy_writer;
     stan::callbacks::stream_logger logger{*outstream, *outstream, *outstream,
                                           *outstream, *outstream};
@@ -305,12 +304,12 @@ class bs_model {
     std::vector<double> initial_value;
     if (jacobian) {
       initial_value = stan::services::util::initialize<true>(
-          *model_, inits_context, rng, init_radius, false, logger, dummy_writer,
-          max_tries);
+          *model_, *inits_context, rng, init_radius, false, logger,
+          dummy_writer, max_tries);
     } else {
       initial_value = stan::services::util::initialize<false>(
-          *model_, inits_context, rng, init_radius, false, logger, dummy_writer,
-          max_tries);
+          *model_, *inits_context, rng, init_radius, false, logger,
+          dummy_writer, max_tries);
     }
     std::memcpy(theta_unc, initial_value.data(),
                 sizeof(double) * initial_value.size());


### PR DESCRIPTION
Re-uses some code we had for the data in `bs_model_construct`, which has already allowed NULL