### PR TITLE
Python: move windows dll setup to after possible compilation

### DIFF
--- a/python/bridgestan/model.py
+++ b/python/bridgestan/model.py
@@ -134,13 +134,12 @@ class StanModel:
             else:
                 data = stanio.dump_stan_json(data)
 
-        windows_dll_path_setup()
-
         if str(model_lib).endswith(".stan"):
             model_lib = compile_model(
                 model_lib, make_args=make_args, stanc_args=stanc_args
             )
 
+        windows_dll_path_setup()
         self.lib_path = fspath(Path(model_lib).absolute().resolve())
         if warn and hasattr(dllist, "dllist") and self.lib_path in dllist.dllist():
             warnings.warn(


### PR DESCRIPTION
If someone installs bridgestan for the first time and immediately calls `bridgestan.StanModel` with a `.stan` file, the `windows_dll_setup` function will be called _before_ TBB was ever built, which causes it to fail (observed in https://github.com/flatironinstitute/walnuts/pull/78). Moving it below the branch which can call compile fixes this, and was where the similar function was already called in the other languages