### PR TITLE
Quote Make arguments when compiling models from R interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,17 +72,17 @@ endif
 %.hpp : %.stan $(STANC)
 	@echo ''
 	@echo '--- Translating Stan model to C++ code ---'
-	$(STANC) $(STANCFLAGS) --o=$(subst  \,/,$@) $(subst  \,/,$<)
+	$(STANC) $(STANCFLAGS) --o="$(subst \,/,$@)" "$(subst \,/,$<)"
 
 %.o : %.hpp $(USER_HEADER)
 	@echo ''
 	@echo '--- Compiling C++ code ---'
-	$(COMPILE.cpp) $(USER_INCLUDE) -x c++ -o $(subst  \,/,$*).o $(subst \,/,$<)
+	$(COMPILE.cpp) $(USER_INCLUDE) -x c++ -o "$(subst \\,/,$*).o" "$(subst \\,/,$<)"
 
 %_model.so : %.o $(BRIDGE_O) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)
 	@echo ''
 	@echo '--- Linking C++ code ---'
-	$(LINK.cpp) -shared -lm -o $(patsubst %.o, %_model.so, $(subst \,/,$<)) $(subst \,/,$*.o) $(BRIDGE_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)
+	$(LINK.cpp) -shared -lm -o "$(patsubst %.o,%_model.so,$(subst \\,/,$<))" "$(subst \,/,$*.o)" $(BRIDGE_O) $(LDLIBS) $(SUNDIALS_TARGETS) $(MPI_TARGETS) $(TBB_TARGETS)
 
 .PHONY: docs
 docs:

--- a/R/R/compile.R
+++ b/R/R/compile.R
@@ -129,7 +129,7 @@ compile_model <- function(stan_file, stanc_args = NULL, make_args = NULL) {
     paste("-C", shQuote(get_bridgestan_path())),
     make_args,
     paste0("STANCFLAGS=", shQuote(stancflags)),
-    output
+    shQuote(output)
   )
 
   suppressWarnings({

--- a/R/R/compile.R
+++ b/R/R/compile.R
@@ -126,9 +126,9 @@ compile_model <- function(stan_file, stanc_args = NULL, make_args = NULL) {
   stancflags <- paste("--include-paths=.", paste(stanc_args, collapse = " "))
 
   flags <- c(
-    paste("-C", get_bridgestan_path()),
+    paste("-C", shQuote(get_bridgestan_path())),
     make_args,
-    paste0("STANCFLAGS=\"", stancflags, "\""),
+    paste0("STANCFLAGS=", shQuote(stancflags)),
     output
   )
 

--- a/R/tests/testthat/test_compile.R
+++ b/R/tests/testthat/test_compile.R
@@ -1,5 +1,4 @@
-test_that("compilation works", {
-  name <- "multi"
+check_compile_model_works <- function(name) {
   file <- file.path(base, "test_models", name, paste0(name, ".stan"))
 
   lib <- file.path(base, "test_models", name, paste0(name, "_model.so"))
@@ -13,6 +12,23 @@ test_that("compilation works", {
   unlink(lib, force = TRUE)
 
   out <- compile_model(file, make_args = c("STAN_THREADS=True"))
+}
+
+test_that("compilation works", {
+  check_compile_model_works(name = "multi")
+})
+
+test_that("compilation with bridgestan path containing spaces works", {
+  temp_dir <- withr::local_tempdir(pattern = "Bridge Stan")
+  bridgestan_path <- get_bridgestan_path(download = TRUE)
+  file.copy(bridgestan_path, temp_dir, recursive = TRUE)
+  temp_bridgestan_path <- file.path(temp_dir, basename(bridgestan_path))
+  verify_bridgestan_path(temp_bridgestan_path)
+  withr::with_envvar(c("BRIDGESTAN" = temp_bridgestan_path), {
+    bridgestan_path <- get_bridgestan_path(download = FALSE)
+    expect_equal(bridgestan_path, temp_bridgestan_path)
+    check_compile_model_works(name = "multi")
+  })
 })
 
 test_that("compilation fails on non-stan file", {

--- a/R/tests/testthat/test_compile.R
+++ b/R/tests/testthat/test_compile.R
@@ -1,4 +1,6 @@
 check_compile_model_works <- function(name) {
+  base <- get_bridgestan_path(download = FALSE)
+
   file <- file.path(base, "test_models", name, paste0(name, ".stan"))
 
   lib <- file.path(base, "test_models", name, paste0(name, "_model.so"))

--- a/julia/test/compile_tests.jl
+++ b/julia/test/compile_tests.jl
@@ -6,22 +6,41 @@ using Test
 models = joinpath(BridgeStan.get_bridgestan_path(), "test_models/")
 
 
-@testset "compile good" begin
-    stanfile = joinpath(models, "multi", "multi.stan")
+function test_compile(stanfile; check_threads = true)
     lib = splitext(stanfile)[1] * "_model.so"
     rm(lib, force = true)
     res = BridgeStan.compile_model(stanfile; stanc_args = ["--O1"])
     @test Base.samefile(lib, res)
     rm(lib)
 
-    # test constructor triggered compilation
-    model = BridgeStan.StanModel(
-        stanfile,
-        joinpath(models, "multi", "multi.data.json");
-        make_args = ["STAN_THREADS=true"],
-    )
-    @test isfile(lib)
-    @test contains(BridgeStan.model_info(model), "STAN_THREADS=true")
+    if check_threads
+        # test constructor triggered compilation
+        model = BridgeStan.StanModel(
+            stanfile,
+            joinpath(models, "multi", "multi.data.json");
+            make_args = ["STAN_THREADS=true"],
+        )
+        @test isfile(lib)
+        @test contains(BridgeStan.model_info(model), "STAN_THREADS=true")
+    end
+end
+
+@testset "compile with space in path" begin
+    bridgestan_path = get_bridgestan_path()
+    mktempdir(prefix = "Bridge Stan") do d
+        cp(bridgestan_path, d, force = true)
+        set_bridgestan_path!(d)
+        test_compile(
+            joinpath(d, "test_models", "multi", "multi.stan");
+            check_threads = false,
+        )
+    end
+    set_bridgestan_path!(bridgestan_path)
+end
+
+
+@testset "compile good" begin
+    test_compile(joinpath(models, "multi", "multi.stan"))
 end
 
 

--- a/python/test/test_compile.py
+++ b/python/test/test_compile.py
@@ -1,3 +1,6 @@
+import contextlib
+import shutil
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -7,21 +10,40 @@ import bridgestan as bs
 STAN_FOLDER = Path(__file__).parent.parent.parent / "test_models"
 
 
-def test_compile_good():
-    stanfile = STAN_FOLDER / "multi" / "multi.stan"
+def check_compile(stanfile, check_threads=True):
     lib = bs.compile.generate_so_name(stanfile)
     lib.unlink(missing_ok=True)
     res = bs.compile_model(stanfile, stanc_args=["--O1"])
     assert lib.samefile(res)
     lib.unlink()
 
-    model = bs.StanModel(
-        stanfile,
-        data=STAN_FOLDER / "multi" / "multi.data.json",
-        make_args=["STAN_THREADS=true"],
-    )
-    assert lib.exists()
-    assert "STAN_THREADS=true" in model.model_info()
+    if check_threads:
+        model = bs.StanModel(
+            stanfile,
+            data=STAN_FOLDER / "multi" / "multi.data.json",
+            make_args=["STAN_THREADS=true"],
+        )
+        assert lib.exists()
+        assert "STAN_THREADS=true" in model.model_info()
+
+
+def test_compile_with_spaces():
+    bridgestan_path = bs.compile.get_bridgestan_path()
+    with tempfile.TemporaryDirectory(
+        suffix="Bridge Stan"
+    ) as d, contextlib.ExitStack() as e:
+        e.callback(lambda: bs.set_bridgestan_path(bridgestan_path))
+
+        shutil.copytree(bridgestan_path, d, dirs_exist_ok=True)
+        bs.set_bridgestan_path(d)
+
+        check_compile(
+            Path(d) / "test_models" / "multi" / "multi.stan", check_threads=False
+        )
+
+
+def test_compile_good():
+    check_compile(STAN_FOLDER / "multi" / "multi.stan")
 
 
 def test_compile_user_header():


### PR DESCRIPTION
Potentially resolves #340 

Uses base R `shQuote` function to quote output of `get_bridgestan_path` and `stancflags` passed as arguments to Make in calls to `compile_model` from R interface, to avoid possible issues with for example spaces in paths being otherwise interpreted as an argument separator.

Also adds a test that temporarily sets `BRIDGESTAN` environment variable to point to a temporary directory containing spaces in the path (and with BridgeStan source copied to that directory), and checks whether a model can be compiled successfully. Before changes to `compile.R` in this PR this test fail while it is passing locally for me after changes.